### PR TITLE
refactor: change the data contained in jwt for performance and add comments, error handlers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,11 @@
     "import/no-extraneous-dependencies": 0,
     "import/extensions": 0,
     "import/no-unresolved": 0,
-    "no-unused-vars": "warn"
+    "no-unused-vars": "warn",
+    "lines-between-class-members": [
+      "error",
+      "always",
+      { "exceptAfterSingleLine": true }
+    ]
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import ormconfig from '@/database/config/ormconfig';
 import authRouter from '@/routes/auth';
 import userRouter from '@/routes/user';
 import swaggerRouter from '@/routes/docs';
+import errorHandler, { noExistReqErrorHandler } from '@/errors/errorHandler';
 
 dotenv.config();
 
@@ -55,8 +56,12 @@ app.use('/user', userRouter);
 
 // 연결 확인용
 app.get('/', (req, res) => {
-  res.send('Welcome to Sasil Server!');
+  res.status(200).send('Welcome to Sasil Server!');
 });
+
+// 에러 처리
+app.use(noExistReqErrorHandler);
+app.use(errorHandler);
 
 app.listen(REAL_SETTING.port, () => {
   console.log(`server is running on ${REAL_SETTING.port}`);

--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -1,6 +1,7 @@
 import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
 
+import { AuthenticationError } from '@/errors/customErrors';
 import User from '@/database/entity/user';
 
 dotenv.config();
@@ -16,8 +17,7 @@ export const jwtVerify = async (token: string) => {
     const decoded = jwt.verify(token, process.env.JWT_SECRET!) as User;
     return decoded.id;
   } catch (error) {
-    console.log(error);
-    return null;
+    throw new AuthenticationError(403, '유효하지 않은 JWT 토큰입니다.');
   }
 };
 

--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -1,35 +1,21 @@
 import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
 
-import { getUserByLoginInfo } from '@/database/controllers/user';
-import { LoginTypes } from '@/database/entity/user';
+import User from '@/database/entity/user';
 
 dotenv.config();
 
-interface DecodedType {
-  email: string;
-  loginType: LoginTypes;
-  iat: number;
-}
-
 export const jwtVerify = async (token: string) => {
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as DecodedType;
-    const userData = await getUserByLoginInfo(decoded.email, decoded.loginType);
-
-    // 유저 정보를 jwt토큰 데이터를 이용해서 받아왔다면 유저 데이터 전송
-    if (!userData) {
-      return null;
-    }
-
-    return userData;
+    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as User;
+    return decoded.id;
   } catch (error) {
     console.log(error);
     return null;
   }
 };
 
-export const makeJWTToken = (email: string, loginType: LoginTypes) => {
-  const token = jwt.sign({ email, loginType }, process.env.JWT_SECRET!);
+export const makeJWTToken = (userData: User) => {
+  const token = jwt.sign(userData, process.env.JWT_SECRET!);
   return token;
 };

--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -5,6 +5,12 @@ import User from '@/database/entity/user';
 
 dotenv.config();
 
+/**
+ * jwt를 decode하여 유저의 id값 반환하는 함수
+ *
+ * @param token 로그인하여 받아온 jwt
+ * @returns 유저의 id값
+ */
 export const jwtVerify = async (token: string) => {
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET!) as User;
@@ -15,6 +21,12 @@ export const jwtVerify = async (token: string) => {
   }
 };
 
+/**
+ * jwt 생성하는 함수
+ *
+ * @param userData 유저 데이터
+ * @returns 유저 데이터로 생성된 jwt
+ */
 export const makeJWTToken = (userData: User) => {
   const token = jwt.sign(userData, process.env.JWT_SECRET!);
   return token;

--- a/src/auth/social/apple.ts
+++ b/src/auth/social/apple.ts
@@ -15,6 +15,12 @@ interface UserAuthData {
 
 type DeviceTypes = 'web' | 'mobile';
 
+/**
+ * server_id(client_id)로 client secret를 생성하여 반환하는 함수
+ *
+ * @param clientId web: server_id / mobile: 형식은 web과 동일하나 맨 뒤 요소는 앱 이름으로 대체
+ * @returns client_secret
+ */
 const createSignWithAppleSecret = (clientId: string) => {
   const token = jwt.sign({}, process.env.APPLE_SECRET_KEY!, {
     algorithm: 'ES256',
@@ -28,13 +34,20 @@ const createSignWithAppleSecret = (clientId: string) => {
   return token;
 };
 
+/**
+ * 프론트에서 애플 로그인 후 받은 인증 코드로 백엔드에서 재인증, 이후 받아온 idToken 반환하는 함수
+ *
+ * @param code 프론트에서 애플 로그인 후 받은 인증 코드
+ * @param deviceType mobile과 web의 server id를 구분하기 위한 인자 ("apple-web" | "apple-mobile")
+ * @returns 재인증을 통해 받은 idToken
+ */
 export const getAppleToken = async (code: string, deviceType: DeviceTypes) => {
   const clientId =
     deviceType === 'web'
       ? process.env.APPLE_CLIENT_ID_WEB!
       : process.env.APPLE_CLIENT_ID_MOBILE!;
 
-  return axios.post(
+  const response = await axios.post(
     'https://appleid.apple.com/auth/token',
     qs.stringify({
       grant_type: 'authorization_code',
@@ -49,12 +62,21 @@ export const getAppleToken = async (code: string, deviceType: DeviceTypes) => {
       },
     },
   );
+
+  const idToken = jwt.decode(response.data.id_token) as UserAuthData;
+  return idToken;
 };
 
+/**
+ * 애플 소셜 로그인 인증 후 회원가입 및 로그인 처리하는 함수
+ *
+ * @param token 프론트에서 애플 로그인 후 받은 authorization_code
+ * @param deviceType mobile과 web의 server id를 구분하기 위한 인자 ("apple-web" | "apple-mobile")
+ * @returns 로그인/회원가입 처리 후 해당 유저 데이터 반환 (추후 jwt 토큰 생성)
+ */
 const verifyApple = async (token: string, deviceType: DeviceTypes) => {
   try {
-    const response = await getAppleToken(token, deviceType);
-    const idToken = jwt.decode(response.data.id_token) as UserAuthData;
+    const idToken = await getAppleToken(token, deviceType);
 
     if (idToken) {
       const { email } = idToken;

--- a/src/auth/social/apple.ts
+++ b/src/auth/social/apple.ts
@@ -80,7 +80,6 @@ const verifyApple = async (token: string, deviceType: DeviceTypes) => {
   try {
     idToken = await getAppleToken(token, deviceType);
   } catch (error) {
-    console.log(error); // TODO: 원래 에러는 어떻게 처리할지 정하기
     throw new AuthenticationError(
       403,
       '프론트에서 애플 로그인 후 전달받은 토큰이 유효하지 않습니다.',

--- a/src/auth/social/google.ts
+++ b/src/auth/social/google.ts
@@ -28,7 +28,6 @@ const verifyGoogle = async (token: string) => {
     });
     payload = ticket.getPayload() as UserAuthData;
   } catch (error) {
-    console.log(error); // TODO: 원래 에러는 어떻게 처리할지 정하기
     throw new AuthenticationError(
       403,
       '프론트에서 구글 로그인 후 전달받은 토큰이 유효하지 않습니다.',

--- a/src/auth/social/google.ts
+++ b/src/auth/social/google.ts
@@ -11,6 +11,12 @@ interface UserAuthData {
 
 const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 
+/**
+ * 구글 소셜 로그인 인증 후 회원가입 및 로그인 처리하는 함수
+ *
+ * @param token 프론트에서 구글 로그인 후 받은 idToken
+ * @returns 로그인/회원가입 처리 후 해당 유저 데이터 반환 (추후 jwt 토큰 생성)
+ */
 const verifyGoogle = async (token: string) => {
   try {
     const ticket = await client.verifyIdToken({

--- a/src/auth/social/kakao.ts
+++ b/src/auth/social/kakao.ts
@@ -23,7 +23,6 @@ const verifyKakao = async (token: string) => {
 
     resData = response.data;
   } catch (error) {
-    console.log(error); // TODO: 원래 에러는 어떻게 처리할지 정하기
     throw new AuthenticationError(
       403,
       '프론트에서 카카오 로그인 후 전달받은 토큰이 유효하지 않습니다.',

--- a/src/auth/social/kakao.ts
+++ b/src/auth/social/kakao.ts
@@ -4,6 +4,12 @@ import { getUserByLoginInfo, addUser } from '@/database/controllers/user';
 
 const kakaoVerifyURL = 'https://kapi.kakao.com/v2/user/me';
 
+/**
+ * 카카오 소셜 로그인 인증 후 회원가입 및 로그인 처리하는 함수
+ *
+ * @param token 프론트에서 카카오 로그인 후 받은 access_token
+ * @returns 로그인/회원가입 처리 후 해당 유저 데이터 반환 (추후 jwt 토큰 생성)
+ */
 const verifyKakao = async (token: string) => {
   try {
     const response = await axios.get(kakaoVerifyURL, {

--- a/src/database/controllers/user.ts
+++ b/src/database/controllers/user.ts
@@ -2,6 +2,12 @@ import { getRepository } from 'typeorm';
 
 import UserEntity, { LoginTypes } from '@/database/entity/user';
 
+/**
+ * id값으로 DB에서 유저 데이터 가져와 반환하는 함수
+ *
+ * @param id 유저의 id값
+ * @returns 유저 데이터
+ */
 export const getUserById = async (id: number) => {
   const userData = await getRepository(UserEntity)
     .createQueryBuilder('user')
@@ -11,6 +17,13 @@ export const getUserById = async (id: number) => {
   return userData;
 };
 
+/**
+ * email, loginType으로 DB에서 유저 데이터 가져와 반환하는 함수
+ *
+ * @param email 유저의 email
+ * @param loginType 소셜 로그인 종류 ("apple" | "google" | "kakao")
+ * @returns 유저 데이터
+ */
 export const getUserByLoginInfo = async (
   email: string,
   loginType: LoginTypes,
@@ -24,9 +37,17 @@ export const getUserByLoginInfo = async (
   return userData;
 };
 
+/**
+ * 회원가입 기능을 하는 함수
+ *
+ * @param email 유저의 email
+ * @param nickname 랜덤 생성된 유저의 nickname
+ * @param loginType 소셜 로그인 종류 ("apple" | "google" | "kakao")
+ * @returns 유저 데이터
+ */
 export const addUser = async (
   email: string,
-  name: string,
+  nickname: string,
   loginType: LoginTypes,
 ) => {
   const userRepository = getRepository(UserEntity);
@@ -34,7 +55,7 @@ export const addUser = async (
   const newUserData = userRepository.create({
     email,
     login_type: loginType,
-    nickname: name, // TODO: random 생성
+    nickname, // TODO: random 생성
   });
 
   await userRepository.save(newUserData);

--- a/src/database/controllers/user.ts
+++ b/src/database/controllers/user.ts
@@ -17,7 +17,6 @@ export const getUserById = async (id: number) => {
 
   if (!userData) {
     throw new DatabaseError(
-      500,
       'userId로 DB에서 유저 데이터를 가져오는데 실패하였습니다.',
     );
   }
@@ -44,7 +43,6 @@ export const getUserByLoginInfo = async (
 
   if (!userData) {
     throw new DatabaseError(
-      500,
       'email, loginType으로 DB에서 유저 데이터를 가져오는데 실패하였습니다.',
     );
   }
@@ -74,10 +72,7 @@ export const addUser = async (
   });
 
   if (!newUserData) {
-    throw new DatabaseError(
-      500,
-      'DB에서 유저 데이터를 생성하는데 실패하였습니다.',
-    );
+    throw new DatabaseError('DB에서 유저 데이터를 생성하는데 실패하였습니다.');
   }
 
   await userRepository.save(newUserData);

--- a/src/database/controllers/user.ts
+++ b/src/database/controllers/user.ts
@@ -1,5 +1,6 @@
 import { getRepository } from 'typeorm';
 
+import { DatabaseError } from '@/errors/customErrors';
 import UserEntity, { LoginTypes } from '@/database/entity/user';
 
 /**
@@ -13,6 +14,13 @@ export const getUserById = async (id: number) => {
     .createQueryBuilder('user')
     .where('user.id = :id', { id })
     .getOne();
+
+  if (!userData) {
+    throw new DatabaseError(
+      500,
+      'userId로 DB에서 유저 데이터를 가져오는데 실패하였습니다.',
+    );
+  }
 
   return userData;
 };
@@ -33,6 +41,13 @@ export const getUserByLoginInfo = async (
     .where('user.email = :email', { email })
     .andWhere('user.login_type = :loginType', { loginType })
     .getOne();
+
+  if (!userData) {
+    throw new DatabaseError(
+      500,
+      'email, loginType으로 DB에서 유저 데이터를 가져오는데 실패하였습니다.',
+    );
+  }
 
   return userData;
 };
@@ -57,6 +72,13 @@ export const addUser = async (
     login_type: loginType,
     nickname, // TODO: random 생성
   });
+
+  if (!newUserData) {
+    throw new DatabaseError(
+      500,
+      'DB에서 유저 데이터를 생성하는데 실패하였습니다.',
+    );
+  }
 
   await userRepository.save(newUserData);
 

--- a/src/errors/customErrors.ts
+++ b/src/errors/customErrors.ts
@@ -1,0 +1,28 @@
+/* eslint-disable max-classes-per-file */
+class HttpException extends Error {
+  status: number;
+  message: string;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+    this.message = message;
+  }
+}
+
+class AuthenticationError extends HttpException {
+  constructor(status: number, message: string) {
+    super(status, message);
+    this.name = 'AuthenticationError';
+  }
+}
+
+class DatabaseError extends HttpException {
+  constructor(status: number, message: string) {
+    super(status, message);
+    this.name = 'DatabaseError';
+  }
+}
+
+export default HttpException;
+export { AuthenticationError, DatabaseError };

--- a/src/errors/customErrors.ts
+++ b/src/errors/customErrors.ts
@@ -10,6 +10,12 @@ class HttpException extends Error {
   }
 }
 
+/**
+ * 인증 관련 오류 생성자
+ *
+ * @param status 상태 코드
+ * @param message 에러 메시지
+ */
 class AuthenticationError extends HttpException {
   constructor(status: number, message: string) {
     super(status, message);
@@ -17,9 +23,14 @@ class AuthenticationError extends HttpException {
   }
 }
 
+/**
+ * 데이터베이스 관련 오류 생성자 (오류 코드 503으로 고정)
+ *
+ * @param message 에러 메시지
+ */
 class DatabaseError extends HttpException {
-  constructor(status: number, message: string) {
-    super(status, message);
+  constructor(message: string) {
+    super(503, message);
     this.name = 'DatabaseError';
   }
 }

--- a/src/errors/errorHandler.ts
+++ b/src/errors/errorHandler.ts
@@ -21,11 +21,11 @@ const errorHandler = (
 
   if (err instanceof DatabaseError) {
     console.log(err);
-    return res.status(err.status).json({ msg: '데이터베이스 관련 오류' });
+    return res.status(err.status).json({ msg: '데이터베이스 관련 오류' }); // 503 고정
   }
 
   console.log(err);
-  return res.status(500).send('서버 오류');
+  return res.status(500).json({ msg: '서버 오류' });
 };
 
 /**
@@ -36,7 +36,7 @@ export const noExistReqErrorHandler = (
   res: Response,
   next: NextFunction,
 ) => {
-  res.status(404).send('존재하지 않는 URL에 대한 요청 오류');
+  res.status(404).json({ msg: '존재하지 않는 URL에 대한 요청 오류' });
 };
 
 export default errorHandler;

--- a/src/errors/errorHandler.ts
+++ b/src/errors/errorHandler.ts
@@ -15,16 +15,16 @@ const errorHandler = (
   next: NextFunction,
 ) => {
   if (err instanceof AuthenticationError) {
-    console.log(err);
+    next(err);
     return res.status(err.status).json({ msg: '인증 관련 오류' });
   }
 
   if (err instanceof DatabaseError) {
-    console.log(err);
+    next(err);
     return res.status(err.status).json({ msg: '데이터베이스 관련 오류' }); // 503 고정
   }
 
-  console.log(err);
+  next(err);
   return res.status(500).json({ msg: '서버 오류' });
 };
 

--- a/src/errors/errorHandler.ts
+++ b/src/errors/errorHandler.ts
@@ -1,0 +1,42 @@
+import { Request, Response, NextFunction } from 'express';
+
+import HttpException, {
+  AuthenticationError,
+  DatabaseError,
+} from './customErrors';
+
+/**
+ * 에러 종류에 따라 다른 상태값과 에러 메시지를 반환하는 에러 처리 함수(미들웨어)
+ */
+const errorHandler = (
+  err: HttpException,
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (err instanceof AuthenticationError) {
+    console.log(err);
+    return res.status(err.status).json({ msg: '인증 관련 오류' });
+  }
+
+  if (err instanceof DatabaseError) {
+    console.log(err);
+    return res.status(err.status).json({ msg: '데이터베이스 관련 오류' });
+  }
+
+  console.log(err);
+  return res.status(500).send('서버 오류');
+};
+
+/**
+ * 존재하지 않는 URL에 대한 요청에 대해서 404 에러 반환하는 함수(미들웨어)
+ */
+export const noExistReqErrorHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  res.status(404).send('존재하지 않는 URL에 대한 요청 오류');
+};
+
+export default errorHandler;

--- a/src/errors/util.ts
+++ b/src/errors/util.ts
@@ -1,0 +1,11 @@
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * 모든 오류를 .catch() 처리하고 체인의 next() 미들웨어에 전달
+ */
+const wrapAsync =
+  (fn: any) => (req: Request, res: Response, next: NextFunction) => {
+    fn(req, res, next).catch(next);
+  };
+
+export default wrapAsync;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -39,7 +39,7 @@ router.post(`/login/:loginType`, async (req, res, next) => {
 
     // userData가 존재한다는 것은 소셜 인증 + 로그인(회원가입) 성공을 의미
     if (userData) {
-      const token = makeJWTToken(userData.email, userData.login_type);
+      const token = makeJWTToken({ ...userData });
       return res.json({ token });
     }
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -43,7 +43,7 @@ router.post(
       }
     } else {
       throw new AuthenticationError(
-        401,
+        403,
         '요청의 Authorization Header에 소셜로그인 인증 토큰(access_token)이 포함되어 있지 않습니다.',
       );
     }
@@ -51,7 +51,7 @@ router.post(
     // userData가 존재한다는 것은 SNS 인증 + sasil 로그인(회원가입) 성공을 의미
     if (userData) {
       const token = makeJWTToken({ ...userData });
-      return res.json({ token });
+      return res.status(200).json({ token });
     }
 
     // 중간 과정에 문제가 없었는데도 userData에 값이 들어오지 않은 경우 에러 처리

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -2,9 +2,8 @@ import { Request, Response, NextFunction } from 'express';
 import { jwtVerify } from '@/auth/jwt';
 
 /**
-checkLoggedIn 미들웨어로 jwt가 검증되고, 유저데이터를 req.user에 전달해준다.
-각 router에서는 req.user로 받아온 id값을 가지고 controller를 불러와 원하는 결과를 전송한다.
-*/
+ * 로그인한 유저만 해당 API 요청에 대한 응답을 받을 수 있도록 만드는 미들웨어 (각 router에서는 req.userId로 controller를 불러와 원하는 결과를 전송)
+ */
 const checkLoggedIn = async (
   req: Request,
   res: Response,

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -13,10 +13,10 @@ const checkLoggedIn = async (
   const token = req.headers.authorization;
 
   if (token) {
-    const user = await jwtVerify(token);
+    const userId = await jwtVerify(token);
 
-    if (user) {
-      req.user = user;
+    if (userId) {
+      req.userId = userId;
       next();
     } else {
       res.status(401).send('로그인이 필요한 요청입니다.');

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -1,26 +1,27 @@
 import { Request, Response, NextFunction } from 'express';
+
+import { AuthenticationError } from '@/errors/customErrors';
+import wrapAsync from '@/errors/util';
 import { jwtVerify } from '@/auth/jwt';
 
 /**
  * 로그인한 유저만 해당 API 요청에 대한 응답을 받을 수 있도록 만드는 미들웨어 (각 router에서는 req.userId로 controller를 불러와 원하는 결과를 전송)
  */
-const checkLoggedIn = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) => {
-  const token = req.headers.authorization;
+const checkLoggedIn = wrapAsync(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const token = req.headers.authorization;
 
-  if (token) {
-    const userId = await jwtVerify(token);
-
-    if (userId) {
+    if (token) {
+      const userId = await jwtVerify(token);
       req.userId = userId;
       next();
     } else {
-      res.status(401).send('로그인이 필요한 요청입니다.');
+      throw new AuthenticationError(
+        401,
+        '요청의 Authorization Header에 JWT 토큰이 포함되어 있지 않습니다.',
+      );
     }
-  }
-};
+  },
+);
 
 export default checkLoggedIn;

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -1,21 +1,23 @@
-import express from 'express';
+import express, { Request, Response } from 'express';
 
+import wrapAsync from '@/errors/util';
 import { getUserById } from '@/database/controllers/user';
 import checkLoggedIn from './middleware';
 
 const router = express.Router();
 
-router.get('/me', checkLoggedIn, async (req, res) => {
-  try {
-    if (req.userId) {
-      const userData = await getUserById(req.userId);
-      res.status(200).json(userData);
-    } else {
-      res.status(200).json(null);
+router.get(
+  '/me',
+  checkLoggedIn,
+  wrapAsync(async (req: Request, res: Response) => {
+    const userData = await getUserById(req.userId!);
+    if (userData) {
+      return res.status(200).json(userData);
     }
-  } catch (error) {
-    console.log(error);
-  }
-});
+
+    // 중간 과정에 문제가 없었는데도 userData에 값이 들어오지 않은 경우 에러 처리
+    throw new Error('userData가 존재하지 않습니다.');
+  }),
+);
 
 export default router;

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -1,12 +1,15 @@
 import express from 'express';
+
+import { getUserById } from '@/database/controllers/user';
 import checkLoggedIn from './middleware';
 
 const router = express.Router();
 
 router.get('/me', checkLoggedIn, async (req, res) => {
   try {
-    if (req.user) {
-      res.status(200).json(req.user);
+    if (req.userId) {
+      const userData = await getUserById(req.userId);
+      res.status(200).json(userData);
     } else {
       res.status(200).json(null);
     }

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -15,7 +15,7 @@ router.get(
       return res.status(200).json(userData);
     }
 
-    // 중간 과정에 문제가 없었는데도 userData에 값이 들어오지 않은 경우 에러 처리
+    // 중간 과정에 문제가 없었는데도 userData에 값이 들어오지 않은 경우 서버 에러 처리
     throw new Error('userData가 존재하지 않습니다.');
   }),
 );

--- a/src/swagger/components/errors.yaml
+++ b/src/swagger/components/errors.yaml
@@ -1,0 +1,7 @@
+components:
+  schemas:
+    Error:
+      type: 'object'
+      properties:
+        msg:
+          type: 'string'

--- a/src/swagger/routes/auth.yaml
+++ b/src/swagger/routes/auth.yaml
@@ -29,3 +29,27 @@ paths:
                   token:
                     type: string
                     description: sasil-server에서 사용하는 jwt
+        '403':
+          description: 인증 관련 오류 (유효하지 않은 요청)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: 인증 관련 오류 (존재하지 않는 로그인 타입 요청)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '503':
+          description: 데이터베이스 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'

--- a/src/swagger/routes/user.yaml
+++ b/src/swagger/routes/user.yaml
@@ -17,3 +17,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+        '401':
+          description: 인증 관련 오류 (로그인이 필요한 요청)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: 인증 관련 오류 (유효하지 않은 요청)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '503':
+          description: 데이터베이스 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -4,7 +4,7 @@ declare global {
   namespace Express {
     interface User extends UserEntity {}
     interface Request {
-      user?: Record<string, any>;
+      userId?: number;
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
       "@/database/*": ["src/database/*"],
       "@/routes/*": ["src/routes/*"],
       "@/auth/*": ["src/auth/*"],
-      "@/constants/*": ["src/constants/*"]
+      "@/constants/*": ["src/constants/*"],
+      "@/errors/*": ["src/errors/*"]
     }
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
## Issue
#15 

## Description
1. jwt 리팩토링
- 기존 방식) 로그인 시 `email`, `loginType`으로 jwt를 만들었고, 해당 jwt로 서버측에서 DB에 실제 유저가 존재하는지 확인하는 과정이 있었는데, 이로 인해 매번 로그인이 필요한 요청을 보낼 때 마다 추가적으로 DB와 2번 통신했어야 했다.
- 개선 방식) jwt에 들어가는 데이터를 유저 데이터 전체로 변경하고, 로그인이 필요한 요청을 보낼 때는 jwt를 decode해서 들어있는 id값을 그대로 사용하여 추가적인 DB 통신이 사라짐.
-> 잦은 DB 통신은 서버에 부하를 줄 뿐만 아니라, 이미 로그인을 통해 유저임을 인증받고 받아온 jwt를 다시 또 확인하는 과정은 불필요하다고 판단
(혹시 이와 관련해 의견이나 질문있으면 편하게 주십쇼!)

2. 함수 설명을 위한 주석 추가
- Dev-Convention에 맞게 함수에 대한 주석을 추가하였다.

3. 에러 처리
- API
  - auth/login
    - 프론트에서 소셜로그인 후 받은 토큰(access_token)이 유효하지 않음 → 403
    - 요청의 Header에 access_token 없음 → 403
    - 지원하지 않는 로그인 타입 요청 → 404
    - DB 오류 → 503
    - 서버 오류 → 500
  - user/me
    - JWT 토큰이 유효하지 않음 → 403
    - 요청의 Header에 JWT 없음 → 401
    - DB 오류 → 503
    - 서버 오류 → 500
- 존재하지 않는 URL로 요청 -> 404

## Check List

- [x] PR 제목을 commit 규칙에 맞게 작성
- [x] WIP를 붙여야 하는 상황인지 확인
- [x] label 설정
- [x] 작업한 사람 모두를 Assign
- [x] Code Review 요청
