### PR TITLE
fix: separate web and mobile of google login API

### DIFF
--- a/src/auth/social/apple.ts
+++ b/src/auth/social/apple.ts
@@ -39,7 +39,7 @@ const createSignWithAppleSecret = (clientId: string) => {
  * 프론트에서 애플 로그인 후 받은 인증 코드로 백엔드에서 재인증, 이후 받아온 idToken 반환하는 함수
  *
  * @param code 프론트에서 애플 로그인 후 받은 인증 코드
- * @param deviceType mobile과 web의 server id를 구분하기 위한 인자 ("apple-web" | "apple-mobile")
+ * @param deviceType mobile과 web 구분을 위한 인자
  * @returns 재인증을 통해 받은 idToken
  */
 export const getAppleToken = async (code: string, deviceType: DeviceTypes) => {

--- a/src/auth/social/google.ts
+++ b/src/auth/social/google.ts
@@ -17,6 +17,7 @@ type DeviceTypes = 'web' | 'mobile';
  * 구글 소셜 로그인 인증 후 회원가입 및 로그인 처리하는 함수
  *
  * @param token 프론트에서 구글 로그인 후 받은 idToken
+ * @param deviceType mobile과 web 구분을 위한 인자
  * @returns 로그인/회원가입 처리 후 해당 유저 데이터 반환 (추후 jwt 토큰 생성)
  */
 const verifyGoogle = async (token: string, deviceType: DeviceTypes) => {

--- a/src/auth/social/google.ts
+++ b/src/auth/social/google.ts
@@ -11,7 +11,7 @@ interface UserAuthData {
   name: string;
 }
 
-const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
+type DeviceTypes = 'web' | 'mobile';
 
 /**
  * 구글 소셜 로그인 인증 후 회원가입 및 로그인 처리하는 함수
@@ -19,13 +19,20 @@ const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
  * @param token 프론트에서 구글 로그인 후 받은 idToken
  * @returns 로그인/회원가입 처리 후 해당 유저 데이터 반환 (추후 jwt 토큰 생성)
  */
-const verifyGoogle = async (token: string) => {
+const verifyGoogle = async (token: string, deviceType: DeviceTypes) => {
   let payload;
+  const clientId =
+    deviceType === 'web'
+      ? process.env.GOOGLE_CLIENT_ID_WEB!
+      : process.env.GOOGLE_CLIENT_ID_MOBILE!;
+
   try {
+    const client = new OAuth2Client(clientId);
     const ticket = await client.verifyIdToken({
       idToken: token,
-      audience: process.env.GOOGLE_CLIENT_ID,
+      audience: clientId,
     });
+
     payload = ticket.getPayload() as UserAuthData;
   } catch (error) {
     throw new AuthenticationError(

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -8,10 +8,11 @@ import verifyKakao from '@/auth/social/kakao';
 import verifyApple from '@/auth/social/apple';
 
 const LOGIN_TYPE = {
-  google: 'google',
-  kakao: 'kakao',
+  googleWeb: 'google-web',
+  googleMobile: 'google-mobile',
   appleWeb: 'apple-web',
   appleMobile: 'apple-mobile',
+  kakao: 'kakao',
 } as const;
 
 const router = express.Router();
@@ -23,17 +24,20 @@ router.post(
     let userData;
     if (authValue) {
       switch (req.params.loginType) {
-        case LOGIN_TYPE.google:
-          userData = await verifyGoogle(authValue);
+        case LOGIN_TYPE.googleWeb:
+          userData = await verifyGoogle(authValue, 'web');
           break;
-        case LOGIN_TYPE.kakao:
-          userData = await verifyKakao(authValue);
+        case LOGIN_TYPE.googleMobile:
+          userData = await verifyGoogle(authValue, 'mobile');
           break;
         case LOGIN_TYPE.appleWeb:
           userData = await verifyApple(authValue, 'web');
           break;
         case LOGIN_TYPE.appleMobile:
           userData = await verifyApple(authValue, 'mobile');
+          break;
+        case LOGIN_TYPE.kakao:
+          userData = await verifyKakao(authValue);
           break;
         default:
           throw new AuthenticationError(

--- a/src/swagger/routes/auth.yaml
+++ b/src/swagger/routes/auth.yaml
@@ -15,7 +15,7 @@ paths:
           description: 소셜로그인 타입
           schema:
             type: string
-            enum: [google, kakao, apple-web, apple-mobile]
+            enum: [google-web, google-mobile, apple-web, apple-mobile, kakao]
       security:
         - social-login-token: []
       responses:


### PR DESCRIPTION
## Issue
#18 

## Description
구글 로그인의 웹과 모바일에 따른 라우터 구분
기존) `/auth/google` => `/auth/google-web`, `/auth/google-mobile`

카카오는 구글, 애플에서 `idToken`을 사용하는 방식과는 달리 `accessToken`을 사용하므로 변경하지 않음!

## Check List

- [x] PR 제목을 commit 규칙에 맞게 작성
- [x] WIP를 붙여야 하는 상황인지 확인
- [x] label 설정
- [x] 작업한 사람 모두를 Assign
- [x] Code Review 요청
