### PR TITLE
feat: add getting posts apis for main page

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -9,9 +9,10 @@ import { createConnection } from 'typeorm';
 
 import { DEV_SETTING, PROD_SETTING } from '@/constants/index';
 import ormconfig from '@/database/config/ormconfig';
+import swaggerRouter from '@/routes/docs';
 import authRouter from '@/routes/auth';
 import userRouter from '@/routes/user';
-import swaggerRouter from '@/routes/docs';
+import postsRouter from '@/routes/posts';
 import errorHandler, { noExistReqErrorHandler } from '@/errors/errorHandler';
 
 dotenv.config();
@@ -53,6 +54,7 @@ app.use(
 app.use('/docs', swaggerRouter);
 app.use('/auth', authRouter);
 app.use('/user', userRouter);
+app.use('/posts', postsRouter);
 
 // 연결 확인용
 app.get('/', (req, res) => {

--- a/src/database/controllers/posts.ts
+++ b/src/database/controllers/posts.ts
@@ -1,0 +1,127 @@
+import { getRepository } from 'typeorm';
+
+import { DatabaseError } from '@/errors/customErrors';
+import ExperimentEntity from '@/database/entity/experiment';
+import RequestEntity from '@/database/entity/request';
+
+/**
+ * 기준에 따른 실험 게시물 목록을 반환
+ *
+ * @param display posts number
+ * @param page page number
+ * @param sort 정렬 기준 (popular | date)
+ * @returns experiment posts
+ */
+const getExperiments = async (
+  display: number,
+  page: number,
+  sort: 'popular' | 'date',
+) => {
+  const sortType = {
+    popular: 'likeCount',
+    date: 'subexp.created_at',
+  };
+
+  const expData = await getRepository(ExperimentEntity)
+    .createQueryBuilder('experiment')
+    .select([
+      'experiment.id',
+      'experiment.created_at',
+      'experiment.updated_at',
+      'experiment.title',
+      'experiment.thumbnail',
+      'user.id',
+      'user.nickname',
+      'user.profile_img',
+      'categories.id',
+      'categories.name',
+    ])
+    .innerJoin(
+      (qb) =>
+        qb
+          .select(['subexp.id', 'COUNT(likes.id) as likeCount'])
+          .from(ExperimentEntity, 'subexp')
+          .leftJoin('subexp.expLikes', 'likes')
+          .groupBy('subexp.id')
+          .offset((page - 1) * display)
+          .limit(display)
+          .orderBy(sortType[sort], 'DESC'),
+      'topExps',
+      'topExps.subexp_id = experiment.id',
+    )
+    .leftJoin('experiment.user', 'user')
+    .leftJoin('experiment.categories', 'categories')
+    .loadRelationCountAndMap('experiment.likeCount', 'experiment.expLikes')
+    .orderBy('topExps.likeCount', 'DESC')
+    .getMany();
+
+  return expData;
+};
+
+/**
+ * 기준에 따른 의뢰 게시물 목록을 반환
+ *
+ * @param display posts number
+ * @param page page number
+ * @param sort 정렬 기준 (popular | date)
+ * @param state request에 experiment가 있는지에 따른 구분 (all | wait | connected)
+ * @returns request posts
+ */
+const getRequests = async (
+  display: number,
+  page: number,
+  sort: 'popular' | 'date',
+  state: 'all' | 'wait' | 'connected',
+) => {
+  const sortType = {
+    popular: 'likeCount',
+    date: 'subreq.created_at',
+  };
+
+  const reverseState = {
+    all: 'all',
+    wait: 'connected',
+    connected: 'wait',
+  };
+
+  const reqData = await getRepository(RequestEntity)
+    .createQueryBuilder('request')
+    .select([
+      'request.id',
+      'request.created_at',
+      'request.updated_at',
+      'request.title',
+      'request.thumbnail',
+      'request.state',
+      'user.id',
+      'user.nickname',
+      'user.profile_img',
+      'categories.id',
+      'categories.name',
+    ])
+    .innerJoin(
+      (qb) =>
+        qb
+          .select(['subreq.id', 'COUNT(likes.id) as likeCount'])
+          .from(RequestEntity, 'subreq')
+          .where('subreq.state != :reverseState ', {
+            reverseState: reverseState[state],
+          })
+          .leftJoin('subreq.reqLikes', 'likes')
+          .groupBy('subreq.id')
+          .offset((page - 1) * display)
+          .limit(display)
+          .orderBy(sortType[sort], 'DESC'),
+      'topReqs',
+      'topReqs.subreq_id = request.id',
+    )
+    .leftJoin('request.user', 'user')
+    .leftJoin('request.categories', 'categories')
+    .loadRelationCountAndMap('request.likeCount', 'request.reqLikes')
+    .orderBy('topReqs.likeCount', 'DESC')
+    .getMany();
+
+  return reqData;
+};
+
+export { getExperiments, getRequests };

--- a/src/database/controllers/posts.ts
+++ b/src/database/controllers/posts.ts
@@ -18,8 +18,14 @@ const getExperiments = async (
   sort: 'popular' | 'date',
 ) => {
   const sortType = {
-    popular: 'likeCount',
-    date: 'subexp.created_at',
+    popular: {
+      first: 'likeCount',
+      second: 'topExps.likeCount',
+    },
+    date: {
+      first: 'subexp.created_at',
+      second: 'experiment.created_at',
+    },
   };
 
   const expData = await getRepository(ExperimentEntity)
@@ -45,14 +51,14 @@ const getExperiments = async (
           .groupBy('subexp.id')
           .offset((page - 1) * display)
           .limit(display)
-          .orderBy(sortType[sort], 'DESC'),
+          .orderBy(sortType[sort].first, 'DESC'),
       'topExps',
       'topExps.subexp_id = experiment.id',
     )
     .leftJoin('experiment.user', 'user')
     .leftJoin('experiment.categories', 'categories')
     .loadRelationCountAndMap('experiment.likeCount', 'experiment.expLikes')
-    .orderBy('topExps.likeCount', 'DESC')
+    .orderBy(sortType[sort].second, 'DESC')
     .getMany();
 
   return expData;
@@ -74,8 +80,14 @@ const getRequests = async (
   state: 'all' | 'wait' | 'connected',
 ) => {
   const sortType = {
-    popular: 'likeCount',
-    date: 'subreq.created_at',
+    popular: {
+      first: 'likeCount',
+      second: 'topReqs.likeCount',
+    },
+    date: {
+      first: 'subreq.created_at',
+      second: 'request.created_at',
+    },
   };
 
   const reverseState = {
@@ -111,14 +123,14 @@ const getRequests = async (
           .groupBy('subreq.id')
           .offset((page - 1) * display)
           .limit(display)
-          .orderBy(sortType[sort], 'DESC'),
+          .orderBy(sortType[sort].first, 'DESC'),
       'topReqs',
       'topReqs.subreq_id = request.id',
     )
     .leftJoin('request.user', 'user')
     .leftJoin('request.categories', 'categories')
     .loadRelationCountAndMap('request.likeCount', 'request.reqLikes')
-    .orderBy('topReqs.likeCount', 'DESC')
+    .orderBy(sortType[sort].second, 'DESC')
     .getMany();
 
   return reqData;

--- a/src/database/controllers/posts.ts
+++ b/src/database/controllers/posts.ts
@@ -70,14 +70,14 @@ const getExperiments = async (
  * @param display posts number
  * @param page page number
  * @param sort 정렬 기준 (popular | date)
- * @param state request에 experiment가 있는지에 따른 구분 (all | wait | connected)
+ * @param state request에 experiment가 있는지에 따른 구분 (all | wait | answered)
  * @returns request posts
  */
 const getRequests = async (
   display: number,
   page: number,
   sort: 'popular' | 'date',
-  state: 'all' | 'wait' | 'connected',
+  state: 'all' | 'wait' | 'answered',
 ) => {
   const sortType = {
     popular: {
@@ -92,8 +92,8 @@ const getRequests = async (
 
   const reverseState = {
     all: 'all',
-    wait: 'connected',
-    connected: 'wait',
+    wait: 'answered',
+    answered: 'wait',
   };
 
   const reqData = await getRepository(RequestEntity)

--- a/src/database/entity/request.ts
+++ b/src/database/entity/request.ts
@@ -26,8 +26,8 @@ class Request extends BasicEntity {
   @Column('varchar', { length: 255, nullable: true })
   thumbnail!: string;
 
-  @Column({ type: 'enum', enum: ['wait', 'connected'], default: 'wait' })
-  state!: 'wait' | 'connected';
+  @Column({ type: 'enum', enum: ['wait', 'answered'], default: 'wait' })
+  state!: 'wait' | 'answered';
 
   // Request:User = N:1
   @ManyToOne(() => User, (user) => user.requests)

--- a/src/routes/posts.ts
+++ b/src/routes/posts.ts
@@ -43,7 +43,7 @@ router.get(
       displayNum > 0 &&
       pageNum > 0 &&
       (sort === 'date' || sort === 'popular') &&
-      (state === 'all' || state === 'wait' || state === 'connected')
+      (state === 'all' || state === 'wait' || state === 'answered')
     ) {
       const expData = await getRequests(displayNum, pageNum, sort, state);
       return res.json(expData);

--- a/src/routes/posts.ts
+++ b/src/routes/posts.ts
@@ -1,0 +1,56 @@
+import express, { Request, Response } from 'express';
+import wrapAsync from '@/errors/util';
+
+import { getExperiments, getRequests } from '@/database/controllers/posts';
+
+const router = express.Router();
+
+// GET posts/experiment
+// query: display(default: 12), page(default: 1), sort(default: date)
+router.get(
+  '/experiment',
+  wrapAsync(async (req: Request, res: Response) => {
+    const { display = '12', page = '1', sort = 'date' } = req.query;
+    const [displayNum, pageNum] = [Number(display), Number(page)];
+
+    if (
+      displayNum > 0 &&
+      pageNum > 0 &&
+      (sort === 'date' || sort === 'popular')
+    ) {
+      const expData = await getExperiments(displayNum, pageNum, sort);
+      return res.json(expData);
+    }
+
+    throw new Error(); // TODO: 주소가 이상하게 들어온 경우 클라이언트 에러 처리
+  }),
+);
+
+// GET posts/request
+// query: display(default: 12), page(default: 1), sort(default: date), state(default: all)
+router.get(
+  '/request',
+  wrapAsync(async (req: Request, res: Response) => {
+    const {
+      display = '12',
+      page = '1',
+      sort = 'date',
+      state = 'all',
+    } = req.query;
+    const [displayNum, pageNum] = [Number(display), Number(page)];
+
+    if (
+      displayNum > 0 &&
+      pageNum > 0 &&
+      (sort === 'date' || sort === 'popular') &&
+      (state === 'all' || state === 'wait' || state === 'connected')
+    ) {
+      const expData = await getRequests(displayNum, pageNum, sort, state);
+      return res.json(expData);
+    }
+
+    throw new Error(); // TODO: 주소가 이상하게 들어온 경우 클라이언트 에러 처리
+  }),
+);
+
+export default router;

--- a/src/swagger/components/posts.yaml
+++ b/src/swagger/components/posts.yaml
@@ -64,7 +64,7 @@ components:
           type: 'integer'
         state:
           type: string
-          enum: ['wait', 'connected']
+          enum: ['wait', 'answered']
         user:
           type: 'object'
           properties:
@@ -89,7 +89,7 @@ components:
         title: 의뢰 게시물 제목
         thumbnail: 의뢰 게시물 썸네일
         likeCount: 3
-        state: wait (or connected)
+        state: wait (or answered)
         user:
           id: 1
           nickname: test

--- a/src/swagger/components/posts.yaml
+++ b/src/swagger/components/posts.yaml
@@ -1,0 +1,99 @@
+components:
+  schemas:
+    Experiment:
+      type: 'object'
+      properties:
+        id:
+          type: 'integer'
+        created_at:
+          type: 'string'
+        updated_at:
+          type: 'string'
+        title:
+          type: 'string'
+        thumbnail:
+          type: 'string'
+        likeCount:
+          type: 'integer'
+        user:
+          type: 'object'
+          properties:
+            id:
+              type: 'integer'
+            nickname:
+              type: 'string'
+            profile_img:
+              type: 'string'
+              nullable: true
+        categories:
+          type: 'object'
+          properties:
+            id:
+              type: 'integer'
+            name:
+              type: 'string'
+      example:
+        id: 1
+        created_at: 2022-05-19T14:53:43.044Z
+        updated_at: 2022-05-19T14:53:43.044Z
+        title: 실험 게시물 제목
+        thumbnail: 실험 게시물 썸네일
+        likeCount: 3
+        user:
+          id: 1
+          nickname: test
+          profile_img: null(or img url)
+        categories:
+          id: 1
+          name: test
+
+    Request:
+      type: 'object'
+      properties:
+        id:
+          type: 'integer'
+        created_at:
+          type: 'string'
+        updated_at:
+          type: 'string'
+        title:
+          type: 'string'
+        thumbnail:
+          type: 'string'
+        likeCount:
+          type: 'integer'
+        state:
+          type: string
+          enum: ['wait', 'connected']
+        user:
+          type: 'object'
+          properties:
+            id:
+              type: 'integer'
+            nickname:
+              type: 'string'
+            profile_img:
+              type: 'string'
+              nullable: true
+        categories:
+          type: 'object'
+          properties:
+            id:
+              type: 'integer'
+            name:
+              type: 'string'
+      example:
+        id: 1
+        created_at: 2022-05-19T14:53:43.044Z
+        updated_at: 2022-05-19T14:53:43.044Z
+        title: 의뢰 게시물 제목
+        thumbnail: 의뢰 게시물 썸네일
+        likeCount: 3
+        state: wait (or connected)
+        user:
+          id: 1
+          nickname: test
+          profile_img: null(or imgUrl)
+        categories:
+          id: 1
+          name: test

--- a/src/swagger/components/user.yaml
+++ b/src/swagger/components/user.yaml
@@ -13,10 +13,12 @@ components:
           type: 'string'
         login_type:
           type: 'string'
+          enum: ['google', 'kakao', 'apple']
         nickname:
           type: 'string'
         profile_img:
           type: 'string'
+          nullable: true
       example:
         id: 1
         created_at: 2022-03-27T15:56:04.904Z

--- a/src/swagger/routes/posts.yaml
+++ b/src/swagger/routes/posts.yaml
@@ -1,0 +1,70 @@
+tags:
+  - name: Posts
+    description: 게시물 목록 관련 API
+
+paths:
+  /posts/experiment:
+    get:
+      summary: 실험 게시물 목록 조회
+      tags:
+        - Posts
+      parameters:
+        - in: query
+          name: display
+          schema:
+            type: integer
+          description: 실험 게시물 갯수 (default '12')
+        - in: query
+          name: page
+          schema:
+            type: integer
+          description: 실험 게시물 목록 페이지 (default '1')
+        - in: query
+          name: sort
+          schema:
+            type: string
+            enum: ['date', 'popular']
+          description: 정렬 기준 (default 'date')
+      responses:
+        '200':
+          description: 실험 게시물 목록 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Experiment'
+
+  /posts/request:
+    get:
+      summary: 의뢰 게시물 목록 조회
+      tags:
+        - Posts
+      parameters:
+        - in: query
+          name: display
+          schema:
+            type: integer
+          description: 의뢰 게시물 갯수 (default '12')
+        - in: query
+          name: page
+          schema:
+            type: integer
+          description: 의뢰 게시물 목록 페이지 (default '1')
+        - in: query
+          name: sort
+          schema:
+            type: string
+            enum: ['date', 'popular']
+          description: 정렬 기준 (default 'date')
+        - in: query
+          name: state
+          schema:
+            type: string
+            enum: ['all', 'wait', 'connected']
+          description: 조회할 의뢰 게시물의 상태 (default 'all')
+      responses:
+        '200':
+          description: 의뢰 게시물 목록 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Request'

--- a/src/swagger/routes/posts.yaml
+++ b/src/swagger/routes/posts.yaml
@@ -59,7 +59,7 @@ paths:
           name: state
           schema:
             type: string
-            enum: ['all', 'wait', 'connected']
+            enum: ['all', 'wait', 'answered']
           description: 조회할 의뢰 게시물의 상태 (default 'all')
       responses:
         '200':


### PR DESCRIPTION
## Issue
#21 

## Description
메인 페이지를 위한 실험 및 의뢰 게시물 목록 조회 API를 만들었습니다.
실험 및 의뢰 페이지에서도 유사하게 데이터를 가져오기 때문에 확장성을 고려하여 개발하였습니다.
(다음 작업에서 에러 핸들러 리팩토링 진행 예정이라 에러 처리는 아직 안했습니다!)

- 의뢰 게시물 목록 조회: `/posts/request`
  - 쿼리 목록
    - `display`: 갯수 (default: 1, min: 1, max: not yet)
    - `page`: pagination을 위한 페이지 넘버 (default: 1, min: 1, max: not yet)
    - `sort` : 최신순/인기순으로 조회 가능하도록 (default: `date`, `enum: [date, popular]`)
    - `state` : 게시물이 달리지 않은 의뢰 목록/전체 의뢰 목록 가능하도록 (default: `all`, `enum: [all, wait, answered]` 
    -> 게시물이 달린 의뢰 목록도 조회 가능!
- 실험 게시물 목록 조회: `/posts/experiment`
  - 쿼리 목록
    - `display`: 갯수 (default: 1, min: 1, max: not yet)
    - `page`: pagination을 위한 페이지 넘버 (default: 1, min: 1, max: not yet)
    - `sort` : 최신순/인기순으로 조회 가능하도록 (default: `date`, `enum: [date, popular]`) 

## Check List
- [x] PR 제목을 commit 규칙에 맞게 작성
- [x] WIP를 붙여야 하는 상황인지 확인
- [x] label 설정
- [x] 작업한 사람 모두를 Assign
- [x] Code Review 요청
