### PR TITLE
feat: change sortType name from date to recent

### DIFF
--- a/src/database/controllers/posts.ts
+++ b/src/database/controllers/posts.ts
@@ -9,20 +9,20 @@ import RequestEntity from '@/database/entity/request';
  *
  * @param display posts number
  * @param page page number
- * @param sort 정렬 기준 (popular | date)
+ * @param sort 정렬 기준 (popular | recent)
  * @returns experiment posts
  */
 const getExperimentList = async (
   display: number,
   page: number,
-  sort: 'popular' | 'date',
+  sort: 'popular' | 'recent',
 ) => {
   const sortType = {
     popular: {
       first: 'likeCount',
       second: 'topExps.likeCount',
     },
-    date: {
+    recent: {
       first: 'subexp.created_at',
       second: 'experiment.created_at',
     },
@@ -73,14 +73,14 @@ const getExperimentList = async (
  *
  * @param display posts number
  * @param page page number
- * @param sort 정렬 기준 (popular | date)
+ * @param sort 정렬 기준 (popular | recent)
  * @param state request에 experiment가 있는지에 따른 구분 (all | wait | answered)
  * @returns request posts
  */
 const getRequestList = async (
   display: number,
   page: number,
-  sort: 'popular' | 'date',
+  sort: 'popular' | 'recent',
   state: 'all' | 'wait' | 'answered',
 ) => {
   const sortType = {
@@ -88,7 +88,7 @@ const getRequestList = async (
       first: 'likeCount',
       second: 'topReqs.likeCount',
     },
-    date: {
+    recent: {
       first: 'subreq.created_at',
       second: 'request.created_at',
     },

--- a/src/routes/posts.ts
+++ b/src/routes/posts.ts
@@ -10,17 +10,17 @@ import { BadRequestError } from '@/errors/customErrors';
 const router = express.Router();
 
 // GET posts/experiment
-// query: display(default: 12), page(default: 1), sort(default: date)
+// query: display(default: 12), page(default: 1), sort(default: recent)
 router.get(
   '/experiment',
   wrapAsync(async (req: Request, res: Response) => {
-    const { display = '12', page = '1', sort = 'date' } = req.query;
+    const { display = '12', page = '1', sort = 'recent' } = req.query;
     const [displayNum, pageNum] = [Number(display), Number(page)];
 
     if (
       displayNum > 0 &&
       pageNum > 0 &&
-      (sort === 'date' || sort === 'popular')
+      (sort === 'recent' || sort === 'popular')
     ) {
       const expListData = await getExperimentList(displayNum, pageNum, sort);
       return res.json(expListData);
@@ -31,14 +31,14 @@ router.get(
 );
 
 // GET posts/request
-// query: display(default: 12), page(default: 1), sort(default: date), state(default: all)
+// query: display(default: 12), page(default: 1), sort(default: recent), state(default: all)
 router.get(
   '/request',
   wrapAsync(async (req: Request, res: Response) => {
     const {
       display = '12',
       page = '1',
-      sort = 'date',
+      sort = 'recent',
       state = 'all',
     } = req.query;
     const [displayNum, pageNum] = [Number(display), Number(page)];
@@ -46,7 +46,7 @@ router.get(
     if (
       displayNum > 0 &&
       pageNum > 0 &&
-      (sort === 'date' || sort === 'popular') &&
+      (sort === 'recent' || sort === 'popular') &&
       (state === 'all' || state === 'wait' || state === 'answered')
     ) {
       const reqListData = await getRequestList(

--- a/src/swagger/components/posts.yaml
+++ b/src/swagger/components/posts.yaml
@@ -1,107 +1,144 @@
 components:
   schemas:
     Experiment:
-      type: 'object'
-      properties:
-        id:
-          type: 'integer'
-        created_at:
-          type: 'string'
-        updated_at:
-          type: 'string'
-        title:
-          type: 'string'
-        thumbnail:
-          type: 'string'
-        likeCount:
-          type: 'integer'
-        user:
-          type: 'object'
-          properties:
-            id:
-              type: 'integer'
-            nickname:
-              type: 'string'
-            profile_img:
-              type: 'string'
-              nullable: true
-        categories:
-          type: 'array'
-          items:
+      type: 'array'
+      items:
+        type: 'object'
+        properties:
+          id:
+            type: 'integer'
+          created_at:
+            type: 'string'
+          updated_at:
+            type: 'string'
+          title:
+            type: 'string'
+          thumbnail:
+            type: 'string'
+            nullable: true
+          likeCount:
+            type: 'integer'
+          user:
             type: 'object'
             properties:
               id:
                 type: 'integer'
-              name:
+              nickname:
                 type: 'string'
+              profile_img:
+                type: 'string'
+                nullable: true
+          categories:
+            type: 'array'
+            items:
+              type: 'object'
+              properties:
+                id:
+                  type: 'integer'
+                name:
+                  type: 'string'
       example:
-        id: 1
-        created_at: 2022-05-19T14:53:43.044Z
-        updated_at: 2022-05-19T14:53:43.044Z
-        title: 실험 게시물 제목
-        thumbnail: 실험 게시물 썸네일
-        likeCount: 3
-        user:
-          id: 1
-          nickname: test
-          profile_img: null(or img url)
-        categories:
-          - id: 1
-            name: test
-          - id: 2
-            name: test2
+        - id: 1
+          created_at: 2022-05-19T14:53:43.044Z
+          updated_at: 2022-05-19T14:53:43.044Z
+          title: 실험 게시물 제목
+          thumbnail: 실험 게시물 썸네일
+          likeCount: 3
+          user:
+            id: 1
+            nickname: test
+            profile_img: null(or img url)
+          categories:
+            - id: 1
+              name: test
+            - id: 2
+              name: test2
+        - id: 2
+          created_at: 2022-05-19T14:53:43.044Z
+          updated_at: 2022-05-19T14:53:43.044Z
+          title: 실험 게시물 제목
+          thumbnail: 실험 게시물 썸네일
+          likeCount: 3
+          user:
+            id: 1
+            nickname: test
+            profile_img: null(or img url)
+          categories:
+            - id: 1
+              name: test
+            - id: 2
+              name: test2
 
     Request:
-      type: 'object'
-      properties:
-        id:
-          type: 'integer'
-        created_at:
-          type: 'string'
-        updated_at:
-          type: 'string'
-        title:
-          type: 'string'
-        thumbnail:
-          type: 'string'
-        likeCount:
-          type: 'integer'
-        state:
-          type: string
-          enum: ['wait', 'answered']
-        user:
-          type: 'object'
-          properties:
-            id:
-              type: 'integer'
-            nickname:
-              type: 'string'
-            profile_img:
-              type: 'string'
-              nullable: true
-        categories:
-          type: 'array'
-          items:
+      type: 'array'
+      items:
+        type: 'object'
+        properties:
+          id:
+            type: 'integer'
+          created_at:
+            type: 'string'
+          updated_at:
+            type: 'string'
+          title:
+            type: 'string'
+          thumbnail:
+            type: 'string'
+            nullable: true
+          likeCount:
+            type: 'integer'
+          state:
+            type: string
+            enum: ['wait', 'answered']
+          user:
             type: 'object'
             properties:
               id:
                 type: 'integer'
-              name:
+              nickname:
                 type: 'string'
+              profile_img:
+                type: 'string'
+                nullable: true
+          categories:
+            type: 'array'
+            items:
+              type: 'object'
+              properties:
+                id:
+                  type: 'integer'
+                name:
+                  type: 'string'
       example:
-        id: 1
-        created_at: 2022-05-19T14:53:43.044Z
-        updated_at: 2022-05-19T14:53:43.044Z
-        title: 의뢰 게시물 제목
-        thumbnail: 의뢰 게시물 썸네일
-        likeCount: 3
-        state: wait (or answered)
-        user:
-          id: 1
-          nickname: test
-          profile_img: null(or imgUrl)
-        categories:
-          - id: 1
-            name: test
-          - id: 2
-            name: test2
+        - id: 1
+          created_at: 2022-05-19T14:53:43.044Z
+          updated_at: 2022-05-19T14:53:43.044Z
+          title: 의뢰 게시물 제목
+          thumbnail: 의뢰 게시물 썸네일
+          likeCount: 3
+          state: wait (or answered)
+          user:
+            id: 1
+            nickname: test
+            profile_img: null(or imgUrl)
+          categories:
+            - id: 1
+              name: test
+            - id: 2
+              name: test2
+        - id: 2
+          created_at: 2022-05-19T14:53:43.044Z
+          updated_at: 2022-05-19T14:53:43.044Z
+          title: 의뢰 게시물 제목
+          thumbnail: 의뢰 게시물 썸네일
+          likeCount: 3
+          state: wait (or answered)
+          user:
+            id: 1
+            nickname: test
+            profile_img: null(or imgUrl)
+          categories:
+            - id: 1
+              name: test
+            - id: 2
+              name: test2

--- a/src/swagger/routes/posts.yaml
+++ b/src/swagger/routes/posts.yaml
@@ -23,8 +23,8 @@ paths:
           name: sort
           schema:
             type: string
-            enum: ['date', 'popular']
-          description: 정렬 기준 (default 'date')
+            enum: ['recent', 'popular']
+          description: 정렬 기준 (default 'recent')
       responses:
         '200':
           description: 실험 게시물 목록 조회 성공
@@ -70,8 +70,8 @@ paths:
           name: sort
           schema:
             type: string
-            enum: ['date', 'popular']
-          description: 정렬 기준 (default 'date')
+            enum: ['recent', 'popular']
+          description: 정렬 기준 (default 'recent')
         - in: query
           name: state
           schema:


### PR DESCRIPTION
## Issue
#28 

## Description
- 최신순에 대한 네이밍을 `date` -> `recent` 로 변경
- `posts/request`, `posts/experiment` api 반환 타입에 문제가 있어 반영함

## Check List
- [x] PR 제목을 commit 규칙에 맞게 작성
- [x] WIP를 붙여야 하는 상황인지 확인
- [x] label 설정
- [x] 작업한 사람 모두를 Assign
- [x] Code Review 요청
