### PR TITLE
feat: add apis for post-detail-page

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import swaggerRouter from '@/routes/docs';
 import authRouter from '@/routes/auth';
 import userRouter from '@/routes/user';
 import postsRouter from '@/routes/posts';
+import postRouter from '@/routes/post';
 import errorHandler, { notFoundErrorHandler } from '@/errors/errorHandler';
 
 dotenv.config();
@@ -55,6 +56,7 @@ app.use('/docs', swaggerRouter);
 app.use('/auth', authRouter);
 app.use('/user', userRouter);
 app.use('/posts', postsRouter);
+app.use('/post', postRouter);
 
 // 연결 확인용
 app.get('/', (req, res) => {

--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -1,7 +1,7 @@
 import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
 
-import { ForbiddenError } from '@/errors/customErrors';
+import { UnauthorizedError } from '@/errors/customErrors';
 import User from '@/database/entity/user';
 
 dotenv.config();
@@ -17,7 +17,7 @@ export const jwtVerify = async (token: string) => {
     const decoded = jwt.verify(token, process.env.JWT_SECRET!) as User;
     return decoded.id;
   } catch (error) {
-    throw new ForbiddenError('유효하지 않은 JWT 토큰입니다.');
+    throw new UnauthorizedError('유효하지 않은 JWT 토큰입니다.');
   }
 };
 

--- a/src/auth/social/apple.ts
+++ b/src/auth/social/apple.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import jwt from 'jsonwebtoken';
 import qs from 'qs';
 
-import { ForbiddenError } from '@/errors/customErrors';
+import { UnauthorizedError } from '@/errors/customErrors';
 import { PROD_SETTING } from '@/constants/index';
 import { getUserByLoginInfo, addUser } from '@/database/controllers/user';
 
@@ -80,7 +80,7 @@ const verifyApple = async (token: string, deviceType: DeviceTypes) => {
   try {
     idToken = await getAppleToken(token, deviceType);
   } catch (error) {
-    throw new ForbiddenError(
+    throw new UnauthorizedError(
       '프론트에서 애플 로그인 후 전달받은 토큰이 유효하지 않습니다.',
     );
   }

--- a/src/auth/social/google.ts
+++ b/src/auth/social/google.ts
@@ -1,7 +1,7 @@
 import { OAuth2Client } from 'google-auth-library';
 import dotenv from 'dotenv';
 
-import { ForbiddenError } from '@/errors/customErrors';
+import { UnauthorizedError } from '@/errors/customErrors';
 import { getUserByLoginInfo, addUser } from '@/database/controllers/user';
 
 dotenv.config();
@@ -36,7 +36,7 @@ const verifyGoogle = async (token: string, deviceType: DeviceTypes) => {
 
     payload = ticket.getPayload() as UserAuthData;
   } catch (error) {
-    throw new ForbiddenError(
+    throw new UnauthorizedError(
       '프론트에서 구글 로그인 후 전달받은 토큰이 유효하지 않습니다.',
     );
   }

--- a/src/auth/social/kakao.ts
+++ b/src/auth/social/kakao.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { ForbiddenError } from '@/errors/customErrors';
+import { UnauthorizedError } from '@/errors/customErrors';
 import { getUserByLoginInfo, addUser } from '@/database/controllers/user';
 
 const kakaoVerifyURL = 'https://kapi.kakao.com/v2/user/me';
@@ -23,7 +23,7 @@ const verifyKakao = async (token: string) => {
 
     resData = response.data;
   } catch (error) {
-    throw new ForbiddenError(
+    throw new UnauthorizedError(
       '프론트에서 카카오 로그인 후 전달받은 토큰이 유효하지 않습니다.',
     );
   }

--- a/src/database/config/ormconfig.ts
+++ b/src/database/config/ormconfig.ts
@@ -19,7 +19,7 @@ const ormconfig: ormconfigType = {
     password: process.env.DEV_DB_PASSWORD,
     database: DEV_SETTING.db.database,
     synchronize: true,
-    logging: false,
+    logging: true,
     entities: ['src/database/entity/**/*.ts'],
     migrations: ['src/database/migration/**/*.ts'],
     subscribers: ['src/database/subscriber/**/*.ts'],

--- a/src/database/controllers/post.ts
+++ b/src/database/controllers/post.ts
@@ -91,14 +91,14 @@ export const getComments = async (postType: PostType, postId: number) => {
 
   const commentsData = await getRepository(targetEntity)
     .createQueryBuilder(entityName)
-    .where(`${targetEntity}.${idName} = :postId`, { postId })
+    .where(`${entityName}.${idName} = :postId`, { postId })
     .select([
-      `${targetEntity}`,
+      `${entityName}`,
       'commWriter.id',
       'commWriter.nickname',
       'commWriter.profile_img',
     ])
-    .leftJoin(`${targetEntity}.user`, 'commWriter')
+    .leftJoin(`${entityName}.user`, 'commWriter')
     .getMany();
 
   return commentsData;
@@ -134,7 +134,7 @@ export const writeComment = async (
   return newComment;
 };
 
-// 댓글 삭제 (로그인)
+// 댓글 삭제 (로그인, 본인 권한)
 
 // 좋아요 (로그인)
 

--- a/src/database/controllers/post.ts
+++ b/src/database/controllers/post.ts
@@ -165,6 +165,7 @@ export const getReqPostByExpId = async (expId: number) => {
     .leftJoin('experiment.request', 'request')
     .leftJoin('request.user', 'user')
     .loadRelationCountAndMap('request.likeCount', 'request.reqLikes')
+    .loadRelationCountAndMap('request.bookmarkCount', 'request.reqBookmarks')
     .getOne();
 
   return reqPost?.request;

--- a/src/database/controllers/post.ts
+++ b/src/database/controllers/post.ts
@@ -1,6 +1,6 @@
 import { getRepository } from 'typeorm';
 
-import { ForbiddenError } from '@/errors/customErrors';
+import { BadRequestError } from '@/errors/customErrors';
 import ExperimentEntity from '@/database/entity/experiment';
 import RequestEntity from '@/database/entity/request';
 import ReqCommentEntity from '@/database/entity/req-comment';
@@ -112,7 +112,7 @@ export const getRequestPost = async (
 };
 
 /**
- * 의뢰 게시물에 응답한 실험 게시물 목록 반환 (최신순)
+ * 특정 의뢰에 응답한 실험 게시물 목록 반환 (최신순)
  *
  * @param reqId 의뢰 게시물의 id값
  * @returns experiment posts list
@@ -167,7 +167,7 @@ export const getReqPostByExpId = async (expId: number) => {
     .loadRelationCountAndMap('request.likeCount', 'request.reqLikes')
     .getOne();
 
-  return reqPost;
+  return reqPost?.request;
 };
 
 /**
@@ -278,8 +278,8 @@ export const deleteComment = async (
     .execute();
 
   if (deleteCommResult.affected === 0) {
-    throw new ForbiddenError(
-      '존재하지 않는 게시물입니다. (혹은 본인 댓글이 아닙니다.)',
+    throw new BadRequestError(
+      '존재하지 않는 게시물/댓글에 대한 요청입니다. (혹은 본인 댓글이 아닙니다.)',
     );
   }
 };
@@ -346,7 +346,7 @@ export const deleteLike = async (
     .execute();
 
   if (deleteLikeResult.affected === 0) {
-    throw new ForbiddenError('존재하지 않는 게시물입니다.');
+    throw new BadRequestError('존재하지 않는 게시물에 대한 요청입니다.');
   }
 };
 
@@ -412,6 +412,6 @@ export const deleteBookmark = async (
     .execute();
 
   if (deleteBookmarkResult.affected === 0) {
-    throw new ForbiddenError('존재하지 않는 게시물입니다.');
+    throw new BadRequestError('존재하지 않는 게시물에 대한 요청입니다.');
   }
 };

--- a/src/database/controllers/post.ts
+++ b/src/database/controllers/post.ts
@@ -1,0 +1,85 @@
+import { getRepository } from 'typeorm';
+
+import { ServerError } from '@/errors/customErrors';
+import ExperimentEntity from '@/database/entity/experiment';
+import RequestEntity from '@/database/entity/request';
+
+// 만약 의뢰에 따른 실험 게시물 목록 정보를 불러오는 것을 분리하면,
+// getExperimentPost와 getRequestPost 통일 가능
+
+/**
+ * id값에 따른 실험 게시물 정보를 반환
+ *
+ * @param postId 실험 게시물의 id값
+ * @returns request post info | undefined
+ */
+const getExperimentPost = async (postId: number) => {
+  const expPostData = await getRepository(ExperimentEntity)
+    .createQueryBuilder('experiment')
+    .where('experiment.id = :postId', { postId })
+    .select([
+      'experiment',
+      'user.id',
+      'user.nickname',
+      'user.profile_img',
+      'categories.id',
+      'categories.name',
+    ])
+    .leftJoin('experiment.user', 'user')
+    .leftJoin('experiment.categories', 'categories')
+    .loadRelationCountAndMap('experiment.likeCount', 'experiment.expLikes')
+    .loadRelationCountAndMap(
+      'experiment.bookmarkCount',
+      'experiment.expBookmarks',
+    )
+    .getOne();
+
+  // expPostData가 없어도 오류 X
+
+  return expPostData;
+};
+
+/**
+ * id값에 따른 의뢰 게시물 정보를 반환
+ *
+ * @param postId 의뢰 게시물의 id값
+ * @returns request posts info | undefined
+ */
+const getRequestPost = async (postId: number) => {
+  const reqPostData = await getRepository(RequestEntity)
+    .createQueryBuilder('request')
+    .where('request.id = :postId', { postId })
+    .select([
+      'request',
+      'user.id',
+      'user.nickname',
+      'user.profile_img',
+      'categories.id',
+      'categories.name',
+    ])
+    .leftJoin('request.user', 'user')
+    .leftJoin('request.categories', 'categories')
+    .loadRelationCountAndMap('request.likeCount', 'request.reqLikes')
+    .loadRelationCountAndMap('request.bookmarkCount', 'request.reqBookmarks')
+    .getOne();
+
+  // reqPostData가 없어도 오류 X
+
+  return reqPostData;
+};
+
+// 의뢰 게시물에 응답한 실험 게시물 목록
+
+// 댓글 작성 (로그인)
+
+// 댓글 삭제 (로그인)
+
+// 좋아요 (로그인)
+
+// 좋아요 취소 (로그인)
+
+// 북마크 추가 (로그인)
+
+// 북마크 삭제 (로그인)
+
+export { getExperimentPost, getRequestPost };

--- a/src/database/controllers/post.ts
+++ b/src/database/controllers/post.ts
@@ -6,11 +6,12 @@ import RequestEntity from '@/database/entity/request';
 import ReqCommentEntity from '@/database/entity/req-comment';
 import ExpCommentEntity from '@/database/entity/exp-comment';
 import UserEntity from '@/database/entity/user';
+import ReqLikeEntity from '@/database/entity/req-like';
+import ExpLikeEntity from '@/database/entity/exp-like';
+import ReqBookmarkEntity from '@/database/entity/req-bookmark';
+import ExpBookmarkEntity from '@/database/entity/exp-bookmark';
 
 type PostType = 'experiment' | 'request';
-
-// 만약 의뢰에 따른 실험 게시물 목록 정보를 불러오는 것을 분리하면,
-// getExperimentPost와 getRequestPost 통일 가능
 
 /**
  * postId값에 따른 실험 게시물 정보를 반환
@@ -18,7 +19,10 @@ type PostType = 'experiment' | 'request';
  * @param postId 실험 게시물의 id값
  * @returns request post info | undefined
  */
-export const getExperimentPost = async (postId: number) => {
+export const getExperimentPost = async (
+  postId: number,
+  userId: number | undefined,
+) => {
   const expPostData = await getRepository(ExperimentEntity)
     .createQueryBuilder('experiment')
     .where('experiment.id = :postId', { postId })
@@ -39,9 +43,23 @@ export const getExperimentPost = async (postId: number) => {
     )
     .getOne();
 
-  // expPostData가 없어도 오류 X
+  const isLike = userId
+    ? !!(await getRepository(ExpLikeEntity)
+        .createQueryBuilder('exp_like')
+        .where('exp_like.user_id = :userId', { userId })
+        .andWhere('exp_like.exp_id = :postId', { postId })
+        .getOne())
+    : false;
 
-  return expPostData;
+  const isBookmark = userId
+    ? !!(await getRepository(ExpBookmarkEntity)
+        .createQueryBuilder('exp_bookmark')
+        .where('exp_bookmark.user_id = :userId', { userId })
+        .andWhere('exp_bookmark.exp_id = :postId', { postId })
+        .getOne())
+    : false;
+
+  return { ...expPostData, isLike, isBookmark };
 };
 
 /**
@@ -50,7 +68,10 @@ export const getExperimentPost = async (postId: number) => {
  * @param postId 의뢰 게시물의 id값
  * @returns request posts info | undefined
  */
-export const getRequestPost = async (postId: number) => {
+export const getRequestPost = async (
+  postId: number,
+  userId: number | undefined,
+) => {
   const reqPostData = await getRepository(RequestEntity)
     .createQueryBuilder('request')
     .where('request.id = :postId', { postId })
@@ -68,26 +89,93 @@ export const getRequestPost = async (postId: number) => {
     .loadRelationCountAndMap('request.bookmarkCount', 'request.reqBookmarks')
     .getOne();
 
-  // reqPostData가 없어도 오류 X
+  const isLike = userId
+    ? !!(await getRepository(ReqLikeEntity)
+        .createQueryBuilder('req_like')
+        .where('req_like.user_id = :userId', { userId })
+        .andWhere('req_like.req_id = :postId', { postId })
+        .getOne())
+    : false;
 
-  return reqPostData;
+  const isBookmark = userId
+    ? !!(await getRepository(ReqBookmarkEntity)
+        .createQueryBuilder('req_bookmark')
+        .where('req_bookmark.user_id = :userId', { userId })
+        .andWhere('req_bookmark.req_id = :postId', { postId })
+        .getOne())
+    : false;
+
+  return { ...reqPostData, isLike, isBookmark };
 };
 
-// 의뢰 게시물에 응답한 실험 게시물 목록 정보
-// 실험 게시물이 응답한 의뢰 게시물 정보
+// 의뢰 게시물에 응답한 실험 게시물 목록 조회 (최신순)
+export const getExpListByReqId = async (reqId: number) => {
+  const sortType = 'experiment.created_at';
+
+  const expListByReqId = await getRepository(ExperimentEntity)
+    .createQueryBuilder('experiment')
+    .where('experiment.req_id = :reqId', { reqId })
+    .select([
+      'experiment.id',
+      'experiment.created_at',
+      'experiment.updated_at',
+      'experiment.title',
+      'experiment.thumbnail',
+      'user.id',
+      'user.nickname',
+      'user.profile_img',
+    ])
+    .leftJoin('experiment.user', 'user')
+    .loadRelationCountAndMap('experiment.likeCount', 'experiment.expLikes')
+    .orderBy(`${sortType}`, 'DESC')
+    .getMany();
+
+  return expListByReqId;
+};
+
+// 실험 게시물이 응답한 의뢰 게시물 조회
+export const getReqPostByExpId = async (expId: number) => {
+  const reqPost = await getRepository(ExperimentEntity)
+    .createQueryBuilder('experiment')
+    .where('experiment.id = :expId', { expId })
+    .select([
+      'experiment.id',
+      'request.id',
+      'request.created_at',
+      'request.updated_at',
+      'request.title',
+      'request.thumbnail',
+      'user.id',
+      'user.nickname',
+      'user.profile_img',
+    ])
+    .leftJoin('experiment.request', 'request')
+    .leftJoin('request.user', 'user')
+    .loadRelationCountAndMap('request.likeCount', 'request.reqLikes')
+    .getOne();
+
+  return reqPost;
+};
 
 /**
- * postId값에 따른 게시물의 댓글 목록을 반환
+ * postId값에 따른 게시물의 댓글 목록을 반환 (최신순)
  *
  * @param postType 게시물 타입 (request | experiment)
  * @param postId 게시물의 id값
  * @returns request post info | undefined
  */
-export const getComments = async (postType: PostType, postId: number) => {
+export const getComments = async (
+  postType: PostType,
+  postId: number,
+  display: number,
+  page: number,
+) => {
   const [TargetEntity, entityName, idName] =
     postType === 'request'
       ? [ReqCommentEntity, 'req_comment', 'req_id']
       : [ExpCommentEntity, 'exp_comment', 'exp_id'];
+
+  const sortType = `${entityName}.created_at`;
 
   const commentsData = await getRepository(TargetEntity)
     .createQueryBuilder(entityName)
@@ -98,6 +186,9 @@ export const getComments = async (postType: PostType, postId: number) => {
       'commWriter.nickname',
       'commWriter.profile_img',
     ])
+    .orderBy(sortType, 'DESC')
+    .offset((page - 1) * display)
+    .limit(display)
     .leftJoin(`${entityName}.user`, 'commWriter')
     .getMany();
 
@@ -105,19 +196,17 @@ export const getComments = async (postType: PostType, postId: number) => {
 };
 
 // 댓글 작성 (로그인)
-export const writeComment = async (
+export const addComment = async (
   postType: PostType,
   postId: number,
   userId: number,
   content: string,
 ) => {
-  const [TargetEntity, PostEntity] = (
+  const [TargetEntity, PostEntity, entityName] = (
     postType === 'request'
-      ? [ReqCommentEntity, RequestEntity]
-      : [ExpCommentEntity, ExperimentEntity]
+      ? [ReqCommentEntity, RequestEntity, 'req_comment']
+      : [ExpCommentEntity, ExperimentEntity, 'exp_comment']
   ) as any;
-
-  const repository = getRepository(TargetEntity);
 
   const user = new UserEntity();
   user.id = userId;
@@ -130,45 +219,146 @@ export const writeComment = async (
   newComment.user = user;
   newComment[postType] = post;
 
-  await repository.save(newComment);
-  return newComment;
+  await getRepository(TargetEntity)
+    .createQueryBuilder()
+    .insert()
+    .into(entityName)
+    .values(newComment)
+    .updateEntity(false)
+    .execute();
 };
 
 // 댓글 삭제 (로그인, 본인 권한)
 export const deleteComment = async (
   postType: PostType,
+  postId: number,
   commentId: number,
   userId: number,
 ) => {
-  const [TargetEntity, entityName] =
+  const [TargetEntity, entityName, entityId] =
     postType === 'request'
-      ? [ReqCommentEntity, 'req_comment']
-      : [ExpCommentEntity, 'exp_comment'];
+      ? [ReqCommentEntity, 'req_comment', 'req_id']
+      : [ExpCommentEntity, 'exp_comment', 'exp_id'];
 
-  const deleteResult = await getRepository(TargetEntity)
+  const deleteCommResult = await getRepository(TargetEntity)
     .createQueryBuilder(entityName)
     .delete()
     .where(`${entityName}.id = :commentId`, { commentId })
+    .andWhere(`${entityName}.${entityId} = :postId`, { postId })
     .andWhere(`${entityName}.user_id = :userId`, { userId })
     .execute();
 
-  if (deleteResult.affected === 0) {
+  if (deleteCommResult.affected === 0) {
     throw new ForbiddenError(
-      '존재하지 않는 댓글입니다. (혹은 본인 댓글이 아닙니다.)',
+      '존재하지 않는 게시물입니다. (혹은 본인 댓글이 아닙니다.)',
     );
   }
-
-  return deleteResult; // TODO: 어떤 값을 반환할지 결정
 };
 
 // 좋아요 (로그인)
+export const addLike = async (
+  postType: PostType,
+  postId: number,
+  userId: number,
+) => {
+  const [TargetEntity, PostEntity, entityName] = (
+    postType === 'request'
+      ? [ReqLikeEntity, RequestEntity, 'req_like']
+      : [ExpLikeEntity, ExperimentEntity, 'exp_like']
+  ) as any;
+
+  const user = new UserEntity();
+  user.id = userId;
+
+  const post = new PostEntity();
+  post.id = postId;
+
+  const newLike = new TargetEntity();
+  newLike.user = user;
+  newLike[postType] = post;
+
+  await getRepository(TargetEntity)
+    .createQueryBuilder()
+    .insert()
+    .into(entityName)
+    .values(newLike)
+    .updateEntity(false)
+    .execute();
+};
 
 // 좋아요 취소 (로그인)
+export const deleteLike = async (
+  postType: PostType,
+  postId: number,
+  userId: number,
+) => {
+  const [TargetEntity, entityName, entityId] =
+    postType === 'request'
+      ? [ReqLikeEntity, 'req_like', 'req_id']
+      : [ExpLikeEntity, 'exp_like', 'exp_id'];
+
+  const deleteLikeResult = await getRepository(TargetEntity)
+    .createQueryBuilder(entityName)
+    .delete()
+    .where(`${entityName}.${entityId} = :postId`, { postId })
+    .andWhere(`${entityName}.user_id = :userId`, { userId })
+    .execute();
+
+  if (deleteLikeResult.affected === 0) {
+    throw new ForbiddenError('존재하지 않는 게시물입니다.');
+  }
+};
 
 // 북마크 추가 (로그인)
+export const addBookmark = async (
+  postType: PostType,
+  postId: number,
+  userId: number,
+) => {
+  const [TargetEntity, PostEntity, entityName] = (
+    postType === 'request'
+      ? [ReqBookmarkEntity, RequestEntity, 'req_bookmark']
+      : [ExpBookmarkEntity, ExperimentEntity, 'exp_bookmark']
+  ) as any;
+
+  const user = new UserEntity();
+  user.id = userId;
+
+  const post = new PostEntity();
+  post.id = postId;
+
+  const newBookmark = new TargetEntity();
+  newBookmark.user = user;
+  newBookmark[postType] = post;
+
+  await getRepository(TargetEntity)
+    .createQueryBuilder()
+    .insert()
+    .into(entityName)
+    .values(newBookmark)
+    .updateEntity(false)
+    .execute();
+};
 
 // 북마크 삭제 (로그인)
+export const deleteBookmark = async (
+  postType: PostType,
+  postId: number,
+  userId: number,
+) => {
+  const [TargetEntity, entityName, entityId] =
+    postType === 'request'
+      ? [ReqBookmarkEntity, 'req_bookmark', 'req_id']
+      : [ExpBookmarkEntity, 'exp_bookmark', 'exp_id'];
 
-// 의뢰에 응답한 실험 게시물 목록 조회
+  const deleteBookmarkResult = await getRepository(TargetEntity)
+    .createQueryBuilder(entityName)
+    .delete()
+    .where(`${entityName}.${entityId} = :postId`, { postId })
+    .andWhere(`${entityName}.user_id = :userId`, { userId })
+    .execute();
 
-// 실험이 응답한 의뢰 게시물 조회
+  if (deleteBookmarkResult.affected === 0) {
+    throw new ForbiddenError('존재하지 않는 게시물입니다.');
+  }
+};

--- a/src/database/entity/exp-bookmark.ts
+++ b/src/database/entity/exp-bookmark.ts
@@ -1,0 +1,25 @@
+/* eslint-disable import/no-cycle */
+import { Entity, ManyToOne, JoinColumn, PrimaryGeneratedColumn } from 'typeorm';
+
+import User from './user';
+import Experiment from './experiment';
+
+@Entity()
+class ExpBookmark {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @ManyToOne(() => User, (user) => user.expBookmarks)
+  @JoinColumn({
+    name: 'user_id',
+  })
+  user!: User;
+
+  @ManyToOne(() => Experiment, (experiment) => experiment.expBookmarks)
+  @JoinColumn({
+    name: 'exp_id',
+  })
+  experiment!: Experiment;
+}
+
+export default ExpBookmark;

--- a/src/database/entity/experiment.ts
+++ b/src/database/entity/experiment.ts
@@ -13,6 +13,7 @@ import User from './user';
 import Request from './request';
 import ExpComment from './exp-comment';
 import ExpLike from './exp-like';
+import ExpBookmark from './exp-bookmark';
 import Category from './category';
 
 @Entity()
@@ -48,9 +49,9 @@ class Experiment extends BasicEntity {
   @OneToMany(() => ExpLike, (expLike) => expLike.experiment)
   expLikes!: ExpLike[];
 
-  // Exp:User = M:N -> exp_bookmark
-  @ManyToMany(() => User, (user) => user.bookmarkExps)
-  userBookmarks!: User[];
+  // Exp:ExpBookmark = M:N -> exp_bookmark
+  @OneToMany(() => ExpBookmark, (expBookmark) => expBookmark.experiment)
+  expBookmarks!: ExpBookmark[];
 
   // Exp:Category = M:N -> exp_category
   @ManyToMany(() => Category, (category) => category.experiments)

--- a/src/database/entity/req-bookmark.ts
+++ b/src/database/entity/req-bookmark.ts
@@ -1,0 +1,25 @@
+/* eslint-disable import/no-cycle */
+import { Entity, ManyToOne, JoinColumn, PrimaryGeneratedColumn } from 'typeorm';
+
+import User from './user';
+import Request from './request';
+
+@Entity()
+class ReqBookmark {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @ManyToOne(() => User, (user) => user.reqBookmarks)
+  @JoinColumn({
+    name: 'user_id',
+  })
+  user!: User;
+
+  @ManyToOne(() => Request, (request) => request.reqBookmarks)
+  @JoinColumn({
+    name: 'req_id',
+  })
+  request!: Request;
+}
+
+export default ReqBookmark;

--- a/src/database/entity/request.ts
+++ b/src/database/entity/request.ts
@@ -41,7 +41,7 @@ class Request extends BasicEntity {
   @OneToMany(() => Experiment, (experiment) => experiment.request)
   experiments!: Experiment[];
 
-  // Request: ExpComment = 1:N
+  // Request:ReqComment = 1:N
   @OneToMany(() => ReqComment, (reqComment) => reqComment.request)
   reqComments!: ReqComment[];
 

--- a/src/database/entity/request.ts
+++ b/src/database/entity/request.ts
@@ -13,6 +13,7 @@ import User from './user';
 import Experiment from './experiment';
 import ReqComment from './req-comment';
 import ReqLike from './req-like';
+import ReqBookmark from './req-bookmark';
 import Category from './category';
 
 @Entity()
@@ -48,9 +49,9 @@ class Request extends BasicEntity {
   @OneToMany(() => ReqLike, (reqLike) => reqLike.request)
   reqLikes!: ReqLike[];
 
-  // Request:User = M:N -> req_bookmark
-  @ManyToMany(() => User, (user) => user.bookmarkReqs)
-  userBookmarks!: User[];
+  // Request:ReqBookmark = 1:N
+  @OneToMany(() => ReqBookmark, (reqBookmark) => reqBookmark.request)
+  reqBookmarks!: ReqBookmark[];
 
   // Request:Category = M:N -> req_category
   @ManyToMany(() => Category, (category) => category.requests) // req_category

--- a/src/database/entity/user.ts
+++ b/src/database/entity/user.ts
@@ -1,14 +1,16 @@
 /* eslint-disable import/no-cycle */
-import { Entity, Column, OneToMany, ManyToMany, JoinTable } from 'typeorm';
+import { Entity, Column, OneToMany } from 'typeorm';
 
 import BasicEntity from './basic-entity';
 import Experiment from './experiment';
 import ExpComment from './exp-comment';
 import ExpLike from './exp-like';
+import ExpBookmark from './exp-bookmark';
 import Request from './request';
 import ReqComment from './req-comment';
-import Notification from './notification';
 import ReqLike from './req-like';
+import ReqBookmark from './req-bookmark';
+import Notification from './notification';
 
 export type LoginTypes = 'apple' | 'google' | 'kakao';
 
@@ -58,31 +60,13 @@ class User extends BasicEntity {
   @OneToMany(() => ReqLike, (reqLike) => reqLike.user)
   reqLikes!: ReqLike[];
 
-  // User:Exp = M:N -> exp_bookmark
-  @ManyToMany(() => Experiment, (experiment) => experiment.userBookmarks)
-  @JoinTable({
-    name: 'exp_bookmark',
-    joinColumn: {
-      name: 'user_id',
-    },
-    inverseJoinColumn: {
-      name: 'exp_id',
-    },
-  })
-  bookmarkExps!: Experiment[];
+  // User:ExpBookmark = 1:N
+  @OneToMany(() => ExpBookmark, (expBookmark) => expBookmark.user)
+  expBookmarks!: ExpBookmark[];
 
-  // User:Request = M:N -> req_bookmark
-  @ManyToMany(() => Request, (request) => request.userBookmarks)
-  @JoinTable({
-    name: 'req_bookmark',
-    joinColumn: {
-      name: 'user_id',
-    },
-    inverseJoinColumn: {
-      name: 'req_id',
-    },
-  })
-  bookmarkReqs!: Request[];
+  // User:ReqBookmark = 1:N
+  @OneToMany(() => ReqBookmark, (reqBookmark) => reqBookmark.user)
+  reqBookmarks!: ReqBookmark[];
 }
 
 export default User;

--- a/src/errors/customErrors.ts
+++ b/src/errors/customErrors.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-classes-per-file */
 
 /**
- * 400 Bad Request Error
+ * 400 Bad Request Error (요청 실패)
  * @param message 서버에서 확인하는 에러 발생 사유
  */
 class BadRequestError extends Error {
@@ -13,7 +13,7 @@ class BadRequestError extends Error {
 }
 
 /**
- * 401 Unauthorized Error
+ * 401 Unauthorized Error (인증 실패)
  * @param message 서버에서 확인하는 에러 발생 사유
  */
 class UnauthorizedError extends Error {
@@ -25,7 +25,7 @@ class UnauthorizedError extends Error {
 }
 
 /**
- * 403 Forbidden Error (인증 실패)
+ * 403 Forbidden Error (권한 없음)
  * @param message 서버에서 확인하는 에러 발생 사유
  */
 class ForbiddenError extends Error {

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -7,7 +7,7 @@ import { jwtVerify } from '@/auth/jwt';
 /**
  * 로그인한 유저만 해당 API 요청에 대한 응답을 받을 수 있도록 만드는 미들웨어 (각 router에서는 req.userId로 controller를 불러와 원하는 결과를 전송)
  */
-const checkLoggedIn = wrapAsync(
+export const checkLoggedIn = wrapAsync(
   async (req: Request, res: Response, next: NextFunction) => {
     const token = req.headers.authorization;
 
@@ -23,4 +23,16 @@ const checkLoggedIn = wrapAsync(
   },
 );
 
-export default checkLoggedIn;
+// TODO: token이 유효하지 않은 경우 에러처리를 할지, undefined를 반환할지
+export const getUserId = wrapAsync(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const token = req.headers.authorization;
+
+    if (token) {
+      const userId = await jwtVerify(token);
+      req.userId = userId;
+    }
+
+    next();
+  },
+);

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -5,7 +5,7 @@ import wrapAsync from '@/utils/wrapAsync';
 import { jwtVerify } from '@/auth/jwt';
 
 /**
- * 로그인한 유저만 해당 API 요청에 대한 응답을 받을 수 있도록 만드는 미들웨어 (각 router에서는 req.userId로 controller를 불러와 원하는 결과를 전송)
+ * access token을 검증 후, userId 값을 req에 담아서 넘겨주는 미들웨어 (인증 과정에서 실패 시, 오류 발생)
  */
 export const checkLoggedIn = wrapAsync(
   async (req: Request, res: Response, next: NextFunction) => {
@@ -23,7 +23,9 @@ export const checkLoggedIn = wrapAsync(
   },
 );
 
-// TODO: token이 유효하지 않은 경우 에러처리를 할지, undefined를 반환할지
+/**
+ * access token이 있다면 userId 값을 req에 담아주고, 없다면 그냥 스킵하는 미들웨어
+ */
 export const getUserId = wrapAsync(
   async (req: Request, res: Response, next: NextFunction) => {
     const token = req.headers.authorization;

--- a/src/routes/post.ts
+++ b/src/routes/post.ts
@@ -32,11 +32,11 @@ router.get(
     const { userId } = req; // 비회원이 요청 시, userId === undefined
 
     if (!(postType === 'experiment' || postType === 'request')) {
-      throw new NotFoundError('존재하지 않는 요청입니다.');
+      throw new NotFoundError('잘못된 postType을 포함한 요청입니다.');
     }
 
     if (!postId) {
-      throw new BadRequestError('올바르지 않은 요청입니다.');
+      throw new BadRequestError('올바르지 않은 postId값을 포함한 요청입니다.');
     }
 
     const getPostData =
@@ -48,14 +48,14 @@ router.get(
   }),
 );
 
-// 의뢰 게시물에 응답한 실험 게시물 목록 조회 (최신순)
+// 특정 의뢰에 응답한 실험 게시물 목록 조회 (최신순)
 router.get(
   '/request/:reqId/experiments',
   wrapAsync(async (req: Request, res: Response) => {
     const postId = Number(req.params.reqId);
 
     if (!postId) {
-      throw new BadRequestError('올바르지 않은 요청입니다.');
+      throw new BadRequestError('올바르지 않은 postId값을 포함한 요청입니다.');
     }
 
     const expListByReqId = await getExpListByReqId(postId);
@@ -63,14 +63,14 @@ router.get(
   }),
 );
 
-// 실험 게시물이 응답한 의뢰 게시물 조회
+// 특정 실험 게시물이 응답한 의뢰 게시물 정보 조회
 router.get(
   '/experiment/:expId/request',
   wrapAsync(async (req: Request, res: Response) => {
     const postId = Number(req.params.expId);
 
     if (!postId) {
-      throw new BadRequestError('올바르지 않은 요청입니다.');
+      throw new BadRequestError('올바르지 않은 postId값을 포함한 요청입니다.');
     }
 
     const reqPostByExpId = await getReqPostByExpId(postId);
@@ -87,7 +87,7 @@ router.get(
     const [displayNum, pageNum] = [Number(display), Number(page)];
 
     if (!(postType === 'experiment' || postType === 'request')) {
-      throw new NotFoundError('존재하지 않는 요청입니다.');
+      throw new NotFoundError('잘못된 postType을 포함한 요청입니다.');
     }
 
     if (!postId) {
@@ -115,11 +115,11 @@ router.post(
     const { userId } = req;
 
     if (!(postType === 'experiment' || postType === 'request')) {
-      throw new NotFoundError('존재하지 않는 요청입니다.');
+      throw new NotFoundError('잘못된 postType을 포함한 요청입니다.');
     }
 
     if (!postId) {
-      throw new BadRequestError('올바르지 않은 요청입니다.');
+      throw new BadRequestError('올바르지 않은 postId값을 포함한 요청입니다.');
     }
 
     if (!userId) {
@@ -145,11 +145,11 @@ router.delete(
     const { userId } = req;
 
     if (!(postType === 'experiment' || postType === 'request')) {
-      throw new NotFoundError('존재하지 않는 요청입니다.');
+      throw new NotFoundError('잘못된 postType을 포함한 요청입니다.');
     }
 
     if (!commentId || !postId) {
-      throw new BadRequestError('올바르지 않은 요청입니다.');
+      throw new BadRequestError('올바르지 않은 postId값을 포함한 요청입니다.');
     }
 
     if (!userId) {
@@ -162,7 +162,7 @@ router.delete(
   }),
 );
 
-// 좋아요 (로그인)
+// 좋아요 추가 (로그인)
 router.post(
   '/:postType/:postId/like',
   checkLoggedIn,
@@ -171,11 +171,11 @@ router.post(
     const { userId } = req;
 
     if (!(postType === 'experiment' || postType === 'request')) {
-      throw new NotFoundError('존재하지 않는 요청입니다.');
+      throw new NotFoundError('잘못된 postType을 포함한 요청입니다.');
     }
 
     if (!postId) {
-      throw new BadRequestError('올바르지 않은 요청입니다.');
+      throw new BadRequestError('올바르지 않은 postId값을 포함한 요청입니다.');
     }
 
     if (!userId) {
@@ -197,11 +197,11 @@ router.delete(
     const { userId } = req;
 
     if (!(postType === 'experiment' || postType === 'request')) {
-      throw new NotFoundError('존재하지 않는 요청입니다.');
+      throw new NotFoundError('잘못된 postType을 포함한 요청입니다.');
     }
 
     if (!postId) {
-      throw new BadRequestError('올바르지 않은 요청입니다.');
+      throw new BadRequestError('올바르지 않은 postId값을 포함한 요청입니다.');
     }
 
     if (!userId) {
@@ -223,11 +223,11 @@ router.post(
     const { userId } = req;
 
     if (!(postType === 'experiment' || postType === 'request')) {
-      throw new NotFoundError('존재하지 않는 요청입니다.');
+      throw new NotFoundError('잘못된 postType을 포함한 요청입니다.');
     }
 
     if (!postId) {
-      throw new BadRequestError('올바르지 않은 요청입니다.');
+      throw new BadRequestError('올바르지 않은 postId값을 포함한 요청입니다.');
     }
 
     if (!userId) {
@@ -249,11 +249,11 @@ router.delete(
     const { userId } = req;
 
     if (!(postType === 'experiment' || postType === 'request')) {
-      throw new NotFoundError('존재하지 않는 요청입니다.');
+      throw new NotFoundError('잘못된 postType을 포함한 요청입니다.');
     }
 
     if (!postId) {
-      throw new BadRequestError('올바르지 않은 요청입니다.');
+      throw new BadRequestError('올바르지 않은 postId값을 포함한 요청입니다.');
     }
 
     if (!userId) {

--- a/src/routes/post.ts
+++ b/src/routes/post.ts
@@ -9,41 +9,82 @@ import {
 import {
   getExperimentPost,
   getRequestPost,
+  getExpListByReqId,
+  getReqPostByExpId,
   getComments,
-  writeComment,
+  addComment,
   deleteComment,
+  addLike,
+  deleteLike,
+  addBookmark,
+  deleteBookmark,
 } from '@/database/controllers/post';
-import checkLoggedIn from './middleware';
+import { checkLoggedIn, getUserId } from './middleware';
 
 const router = express.Router();
 
 // 게시물 정보 조회
 router.get(
   '/:postType/:postId',
+  getUserId,
   wrapAsync(async (req: Request, res: Response) => {
     const [postType, postId] = [req.params.postType, Number(req.params.postId)];
+    const { userId } = req; // 비회원이 요청 시, userId === undefined
 
     if (!(postType === 'experiment' || postType === 'request')) {
       throw new NotFoundError('존재하지 않는 요청입니다.');
     }
 
     if (!postId) {
-      throw new BadRequestError('올바르지 않은 query를 포함한 요청입니다.');
+      throw new BadRequestError('올바르지 않은 요청입니다.');
     }
 
     const getPostData =
       postType === 'experiment' ? getExperimentPost : getRequestPost;
 
-    const postData = await getPostData(postId);
+    const postData = await getPostData(postId, userId);
+
     return res.json(postData);
   }),
 );
 
-// 게시물에 대한 댓글 정보 조회
+// 의뢰 게시물에 응답한 실험 게시물 목록 조회 (최신순)
+router.get(
+  '/request/:reqId/experiments',
+  wrapAsync(async (req: Request, res: Response) => {
+    const postId = Number(req.params.reqId);
+
+    if (!postId) {
+      throw new BadRequestError('올바르지 않은 요청입니다.');
+    }
+
+    const expListByReqId = await getExpListByReqId(postId);
+    return res.json(expListByReqId);
+  }),
+);
+
+// 실험 게시물이 응답한 의뢰 게시물 조회
+router.get(
+  '/experiment/:expId/request',
+  wrapAsync(async (req: Request, res: Response) => {
+    const postId = Number(req.params.expId);
+
+    if (!postId) {
+      throw new BadRequestError('올바르지 않은 요청입니다.');
+    }
+
+    const reqPostByExpId = await getReqPostByExpId(postId);
+    return res.json(reqPostByExpId);
+  }),
+);
+
+// 게시물에 대한 댓글 목록 조회 (최신순)
 router.get(
   '/:postType/:postId/comments',
   wrapAsync(async (req: Request, res: Response) => {
     const [postType, postId] = [req.params.postType, Number(req.params.postId)];
+    const { display = '12', page = '1' } = req.query;
+    const [displayNum, pageNum] = [Number(display), Number(page)];
 
     if (!(postType === 'experiment' || postType === 'request')) {
       throw new NotFoundError('존재하지 않는 요청입니다.');
@@ -53,7 +94,13 @@ router.get(
       throw new BadRequestError('올바르지 않은 query를 포함한 요청입니다.');
     }
 
-    const commentsData = await getComments(postType, postId);
+    const commentsData = await getComments(
+      postType,
+      postId,
+      displayNum,
+      pageNum,
+    );
+
     return res.json(commentsData);
   }),
 );
@@ -65,51 +112,157 @@ router.post(
   wrapAsync(async (req: Request, res: Response) => {
     const [postType, postId] = [req.params.postType, Number(req.params.postId)];
     const { content } = req.body;
-    const { userId } = req; // chckedLoggedIn middleware를 거치면서 생성
-
-    if (!(postType === 'experiment' || postType === 'request')) {
-      throw new NotFoundError('존재하지 않는 요청입니다.');
-    }
-
-    if (!postId) {
-      throw new BadRequestError('올바르지 않은 query를 포함한 요청입니다.');
-    }
-
-    if (!userId) {
-      throw new UnauthorizedError('로그인이 필요한 요청입니다.');
-    }
-
-    const commentData = await writeComment(postType, postId, userId, content);
-    return res.json(commentData);
-  }),
-);
-
-// 댓글 삭제 (로그인, 본인 권한)
-router.delete(
-  '/:postType/comment/:commentId',
-  checkLoggedIn,
-  wrapAsync(async (req: Request, res: Response) => {
-    const [postType, commentId] = [
-      req.params.postType,
-      Number(req.params.commentId),
-    ];
-
     const { userId } = req;
 
     if (!(postType === 'experiment' || postType === 'request')) {
       throw new NotFoundError('존재하지 않는 요청입니다.');
     }
 
-    if (!commentId) {
-      throw new BadRequestError('올바르지 않은 query를 포함한 요청입니다.');
+    if (!postId) {
+      throw new BadRequestError('올바르지 않은 요청입니다.');
     }
 
     if (!userId) {
       throw new UnauthorizedError('로그인이 필요한 요청입니다.');
     }
 
-    const deleteResult = await deleteComment(postType, commentId, userId);
-    return res.json(deleteResult);
+    await addComment(postType, postId, userId, content);
+
+    res.end();
+  }),
+);
+
+// 댓글 삭제 (로그인, 본인 권한)
+router.delete(
+  '/:postType/:postId/comment/:commentId',
+  checkLoggedIn,
+  wrapAsync(async (req: Request, res: Response) => {
+    const [postType, postId, commentId] = [
+      req.params.postType,
+      Number(req.params.postId),
+      Number(req.params.commentId),
+    ];
+    const { userId } = req;
+
+    if (!(postType === 'experiment' || postType === 'request')) {
+      throw new NotFoundError('존재하지 않는 요청입니다.');
+    }
+
+    if (!commentId || !postId) {
+      throw new BadRequestError('올바르지 않은 요청입니다.');
+    }
+
+    if (!userId) {
+      throw new UnauthorizedError('로그인이 필요한 요청입니다.');
+    }
+
+    await deleteComment(postType, postId, commentId, userId);
+
+    res.end();
+  }),
+);
+
+// 좋아요 (로그인)
+router.post(
+  '/:postType/:postId/like',
+  checkLoggedIn,
+  wrapAsync(async (req: Request, res: Response) => {
+    const [postType, postId] = [req.params.postType, Number(req.params.postId)];
+    const { userId } = req;
+
+    if (!(postType === 'experiment' || postType === 'request')) {
+      throw new NotFoundError('존재하지 않는 요청입니다.');
+    }
+
+    if (!postId) {
+      throw new BadRequestError('올바르지 않은 요청입니다.');
+    }
+
+    if (!userId) {
+      throw new UnauthorizedError('로그인이 필요한 요청입니다.');
+    }
+
+    await addLike(postType, postId, userId);
+
+    return res.end();
+  }),
+);
+
+// 좋아요 취소 (로그인)
+router.delete(
+  '/:postType/:postId/like',
+  checkLoggedIn,
+  wrapAsync(async (req: Request, res: Response) => {
+    const [postType, postId] = [req.params.postType, Number(req.params.postId)];
+    const { userId } = req;
+
+    if (!(postType === 'experiment' || postType === 'request')) {
+      throw new NotFoundError('존재하지 않는 요청입니다.');
+    }
+
+    if (!postId) {
+      throw new BadRequestError('올바르지 않은 요청입니다.');
+    }
+
+    if (!userId) {
+      throw new UnauthorizedError('로그인이 필요한 요청입니다.');
+    }
+
+    await deleteLike(postType, postId, userId);
+
+    return res.end();
+  }),
+);
+
+// 북마크 추가 (로그인)
+router.post(
+  '/:postType/:postId/bookmark',
+  checkLoggedIn,
+  wrapAsync(async (req: Request, res: Response) => {
+    const [postType, postId] = [req.params.postType, Number(req.params.postId)];
+    const { userId } = req;
+
+    if (!(postType === 'experiment' || postType === 'request')) {
+      throw new NotFoundError('존재하지 않는 요청입니다.');
+    }
+
+    if (!postId) {
+      throw new BadRequestError('올바르지 않은 요청입니다.');
+    }
+
+    if (!userId) {
+      throw new UnauthorizedError('로그인이 필요한 요청입니다.');
+    }
+
+    await addBookmark(postType, postId, userId);
+
+    res.end();
+  }),
+);
+
+// 북마크 삭제 (로그인)
+router.delete(
+  '/:postType/:postId/bookmark',
+  checkLoggedIn,
+  wrapAsync(async (req: Request, res: Response) => {
+    const [postType, postId] = [req.params.postType, Number(req.params.postId)];
+    const { userId } = req;
+
+    if (!(postType === 'experiment' || postType === 'request')) {
+      throw new NotFoundError('존재하지 않는 요청입니다.');
+    }
+
+    if (!postId) {
+      throw new BadRequestError('올바르지 않은 요청입니다.');
+    }
+
+    if (!userId) {
+      throw new UnauthorizedError('로그인이 필요한 요청입니다.');
+    }
+
+    await deleteBookmark(postType, postId, userId);
+
+    res.end();
   }),
 );
 

--- a/src/routes/post.ts
+++ b/src/routes/post.ts
@@ -1,0 +1,6 @@
+import express, { Request, Response } from 'express';
+import wrapAsync from '@/utils/wrapAsync';
+
+const router = express.Router();
+
+export default router;

--- a/src/routes/post.ts
+++ b/src/routes/post.ts
@@ -23,7 +23,7 @@ import { checkLoggedIn, getUserId } from './middleware';
 
 const router = express.Router();
 
-// 게시물 정보 조회
+// 게시물 정보 조회 (로그인 [선택])
 router.get(
   '/:postType/:postId',
   getUserId,
@@ -78,7 +78,7 @@ router.get(
   }),
 );
 
-// 게시물에 대한 댓글 목록 조회 (최신순)
+// 게시물의 댓글 목록 조회 (최신순)
 router.get(
   '/:postType/:postId/comments',
   wrapAsync(async (req: Request, res: Response) => {
@@ -97,8 +97,8 @@ router.get(
     const commentsData = await getComments(
       postType,
       postId,
-      displayNum,
       pageNum,
+      displayNum,
     );
 
     return res.json(commentsData);
@@ -132,7 +132,7 @@ router.post(
   }),
 );
 
-// 댓글 삭제 (로그인, 본인 권한)
+// 댓글 삭제 (로그인, 본인만)
 router.delete(
   '/:postType/:postId/comment/:commentId',
   checkLoggedIn,

--- a/src/routes/post.ts
+++ b/src/routes/post.ts
@@ -1,12 +1,14 @@
 import express, { Request, Response } from 'express';
 import wrapAsync from '@/utils/wrapAsync';
 
-import { BadRequestError } from '@/errors/customErrors';
+import { BadRequestError, NotFoundError } from '@/errors/customErrors';
 import {
   getExperimentPost,
   getRequestPost,
   getComments,
+  writeComment,
 } from '@/database/controllers/post';
+import checkLoggedIn from './middleware';
 
 const router = express.Router();
 
@@ -16,15 +18,19 @@ router.get(
   wrapAsync(async (req: Request, res: Response) => {
     const [postType, postId] = [req.params.postType, Number(req.params.postId)];
 
-    if (postId && (postType === 'experiment' || postType === 'request')) {
-      const getPostData =
-        postType === 'experiment' ? getExperimentPost : getRequestPost;
-
-      const postData = await getPostData(postId);
-      return res.json(postData);
+    if (!(postType === 'experiment' || postType === 'request')) {
+      throw new NotFoundError('존재하지 않는 요청입니다.');
     }
 
-    throw new BadRequestError('올바르지 않은 query를 포함한 요청입니다.');
+    if (!postId) {
+      throw new BadRequestError('올바르지 않은 query를 포함한 요청입니다.');
+    }
+
+    const getPostData =
+      postType === 'experiment' ? getExperimentPost : getRequestPost;
+
+    const postData = await getPostData(postId);
+    return res.json(postData);
   }),
 );
 
@@ -34,12 +40,40 @@ router.get(
   wrapAsync(async (req: Request, res: Response) => {
     const [postType, postId] = [req.params.postType, Number(req.params.postId)];
 
-    if (postId && (postType === 'experiment' || postType === 'request')) {
-      const commentsData = await getComments(postType, postId);
-      return res.json(commentsData);
+    if (!(postType === 'experiment' || postType === 'request')) {
+      throw new NotFoundError('존재하지 않는 요청입니다.');
     }
 
-    throw new BadRequestError('올바르지 않은 query를 포함한 요청입니다.');
+    if (!postId) {
+      throw new BadRequestError('올바르지 않은 query를 포함한 요청입니다.');
+    }
+
+    const commentsData = await getComments(postType, postId);
+    return res.json(commentsData);
+  }),
+);
+
+// 댓글 작성 (로그인)
+router.post(
+  '/:postType/:postId/comment',
+  checkLoggedIn,
+  wrapAsync(async (req: Request, res: Response) => {
+    const [postType, postId] = [req.params.postType, Number(req.params.postId)];
+    const [content, userId] = [req.body.content, Number(req.body.userId)];
+
+    if (!(postType === 'experiment' || postType === 'request')) {
+      throw new NotFoundError('존재하지 않는 요청입니다.');
+    }
+
+    if (!postId || !userId) {
+      throw new BadRequestError(
+        '올바르지 않은 query or body를 포함한 요청입니다.',
+      );
+    }
+
+    const test = await writeComment(postType, postId, userId, content);
+
+    return res.json(test);
   }),
 );
 

--- a/src/routes/post.ts
+++ b/src/routes/post.ts
@@ -2,10 +2,15 @@ import express, { Request, Response } from 'express';
 import wrapAsync from '@/utils/wrapAsync';
 
 import { BadRequestError } from '@/errors/customErrors';
-import { getExperimentPost, getRequestPost } from '@/database/controllers/post';
+import {
+  getExperimentPost,
+  getRequestPost,
+  getComments,
+} from '@/database/controllers/post';
 
 const router = express.Router();
 
+// 게시물 정보 조회
 router.get(
   '/:postType/:postId',
   wrapAsync(async (req: Request, res: Response) => {
@@ -17,6 +22,21 @@ router.get(
 
       const postData = await getPostData(postId);
       return res.json(postData);
+    }
+
+    throw new BadRequestError('올바르지 않은 query를 포함한 요청입니다.');
+  }),
+);
+
+// 게시물에 대한 댓글 정보 조회
+router.get(
+  '/:postType/:postId/comments',
+  wrapAsync(async (req: Request, res: Response) => {
+    const [postType, postId] = [req.params.postType, Number(req.params.postId)];
+
+    if (postId && (postType === 'experiment' || postType === 'request')) {
+      const commentsData = await getComments(postType, postId);
+      return res.json(commentsData);
     }
 
     throw new BadRequestError('올바르지 않은 query를 포함한 요청입니다.');

--- a/src/routes/post.ts
+++ b/src/routes/post.ts
@@ -59,7 +59,8 @@ router.post(
   checkLoggedIn,
   wrapAsync(async (req: Request, res: Response) => {
     const [postType, postId] = [req.params.postType, Number(req.params.postId)];
-    const [content, userId] = [req.body.content, Number(req.body.userId)];
+    const { content } = req.body;
+    const { userId } = req; // chckedLoggedIn middleware를 거치면서 생성
 
     if (!(postType === 'experiment' || postType === 'request')) {
       throw new NotFoundError('존재하지 않는 요청입니다.');

--- a/src/routes/post.ts
+++ b/src/routes/post.ts
@@ -1,6 +1,26 @@
 import express, { Request, Response } from 'express';
 import wrapAsync from '@/utils/wrapAsync';
 
+import { BadRequestError } from '@/errors/customErrors';
+import { getExperimentPost, getRequestPost } from '@/database/controllers/post';
+
 const router = express.Router();
+
+router.get(
+  '/:postType/:postId',
+  wrapAsync(async (req: Request, res: Response) => {
+    const [postType, postId] = [req.params.postType, Number(req.params.postId)];
+
+    if (postId && (postType === 'experiment' || postType === 'request')) {
+      const getPostData =
+        postType === 'experiment' ? getExperimentPost : getRequestPost;
+
+      const postData = await getPostData(postId);
+      return res.json(postData);
+    }
+
+    throw new BadRequestError('올바르지 않은 query를 포함한 요청입니다.');
+  }),
+);
 
 export default router;

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -2,7 +2,7 @@ import express, { Request, Response } from 'express';
 
 import wrapAsync from '@/utils/wrapAsync';
 import { getUserById } from '@/database/controllers/user';
-import checkLoggedIn from './middleware';
+import { checkLoggedIn } from './middleware';
 
 const router = express.Router();
 

--- a/src/swagger/components/post.yaml
+++ b/src/swagger/components/post.yaml
@@ -1,0 +1,270 @@
+components:
+  schemas:
+    ExperimentDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+        created_at:
+          type: string
+        updated_at:
+          type: string
+        title:
+          type: string
+        content:
+          type: string
+        thumbnail:
+          type: string
+          nullable: true
+        likeCount:
+          type: integer
+        bookmarkCount:
+          type: integer
+        isLike:
+          type: boolean
+        isBookmark:
+          type: boolean
+        user:
+          type: object
+          properties:
+            id:
+              type: integer
+            nickname:
+              type: string
+            profile_img:
+              type: string
+              nullable: true
+        categories:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+      example:
+        id: 1
+        created_at: 2022-05-19T14:53:43.044Z
+        updated_at: 2022-05-19T14:53:43.044Z
+        title: 실험 게시물 제목
+        content: 게시물 내용
+        thumbnail: 실험 게시물 썸네일 url (or null)
+        likeCount: 3
+        bookmarkCount: 2
+        isLike: true
+        isBookmark: false
+        user:
+          id: 1
+          nickname: test
+          profile_img: 프로필 사진 url (or null)
+        categories:
+          - id: 1
+            name: test
+          - id: 2
+            name: test2
+
+    RequestDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+        created_at:
+          type: string
+        updated_at:
+          type: string
+        title:
+          type: string
+        content:
+          type: string
+        thumbnail:
+          type: string
+          nullable: true
+        likeCount:
+          type: integer
+        bookmarkCount:
+          type: integer
+        isLike:
+          type: boolean
+        isBookmark:
+          type: boolean
+        state:
+          type: string
+          enum: ['wait', 'answered']
+        user:
+          type: object
+          properties:
+            id:
+              type: integer
+            nickname:
+              type: string
+            profile_img:
+              type: string
+              nullable: true
+        categories:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+      example:
+        id: 1
+        created_at: 2022-05-19T14:53:43.044Z
+        updated_at: 2022-05-19T14:53:43.044Z
+        title: 의뢰 게시물 제목
+        content: 게시물 내용
+        thumbnail: 의뢰 게시물 썸네일 url (or null)
+        likeCount: 3
+        bookmarkCount: 2
+        isLike: true
+        isBookmark: false
+        state: answered (or wait)
+        user:
+          id: 1
+          nickname: test
+          profile_img: 프로필 사진 url (or null)
+        categories:
+          - id: 1
+            name: test
+          - id: 2
+            name: test2
+
+    ExperimentListByReq:
+      type: array
+      items:
+        type: object
+        properties:
+          id:
+            type: integer
+          created_at:
+            type: string
+          updated_at:
+            type: string
+          title:
+            type: string
+          thumbnail:
+            type: string
+            nullable: true
+          likeCount:
+            type: integer
+          user:
+            type: object
+            properties:
+              id:
+                type: integer
+              nickname:
+                type: string
+              profile_img:
+                type: string
+                nullable: true
+      example:
+        - id: 1
+          created_at: 2022-05-19T14:53:43.044Z
+          updated_at: 2022-05-19T14:53:43.044Z
+          title: 실험 게시물 제목
+          thumbnail: 실험 게시물 썸네일 url (or null)
+          likeCount: 3
+          user:
+            id: 1
+            nickname: test
+            profile_img: null(or img url)
+        - id: 2
+          created_at: 2022-05-19T14:53:43.044Z
+          updated_at: 2022-05-19T14:53:43.044Z
+          title: 실험 게시물 제목
+          thumbnail: 실험 게시물 썸네일
+          likeCount: 3
+          user:
+            id: 1
+            nickname: test
+            profile_img: 프로필 사진 url (or null)
+
+    RequestForExp:
+      type: object
+      properties:
+        id:
+          type: integer
+        created_at:
+          type: string
+        updated_at:
+          type: string
+        title:
+          type: string
+        thumbnail:
+          type: string
+          nullable: true
+        likeCount:
+          type: integer
+        bookmarkCount:
+          type: integer
+        user:
+          type: object
+          properties:
+            id:
+              type: integer
+            nickname:
+              type: string
+            profile_img:
+              type: string
+              nullable: true
+      example:
+        id: 1
+        created_at: 2022-05-19T14:53:43.044Z
+        updated_at: 2022-05-19T14:53:43.044Z
+        title: 의뢰 게시물 제목
+        thumbnail: 의뢰 게시물 썸네일 url (or null)
+        likeCount: 3
+        bookmarkCount: 1
+        user:
+          id: 1
+          nickname: test
+          profile_img: 프로필 사진 url (or null)
+
+    Comments:
+      type: array
+      items:
+        type: object
+        properties:
+          id:
+            type: integer
+          created_at:
+            type: string
+          updated_at:
+            type: string
+          content:
+            type: string
+          parent_id:
+            type: number
+            nullable: true
+          user:
+            type: object
+            properties:
+              id:
+                type: integer
+              nickname:
+                type: string
+              profile_img:
+                type: string
+                nullable: true
+      example:
+        - id: 1
+          created_at: 2022-05-19T14:53:43.044Z
+          updated_at: 2022-05-19T14:53:43.044Z
+          content: 댓글 내용
+          parent_id: null (대댓글인 경우 존재)
+          user:
+            id: 1
+            nickname: test
+            profile_img: null(or img url)
+        - id: 2
+          created_at: 2022-05-19T14:53:43.044Z
+          updated_at: 2022-05-19T14:53:43.044Z
+          content: 댓글 내용
+          parent_id: null (대댓글인 경우 존재)
+          user:
+            id: 1
+            nickname: test
+            profile_img: 프로필 사진 url (or null)

--- a/src/swagger/components/posts.yaml
+++ b/src/swagger/components/posts.yaml
@@ -1,42 +1,42 @@
 components:
   schemas:
     ExperimentList:
-      type: 'array'
+      type: array
       items:
-        type: 'object'
+        type: object
         properties:
           id:
-            type: 'integer'
+            type: integer
           created_at:
-            type: 'string'
+            type: string
           updated_at:
-            type: 'string'
+            type: string
           title:
-            type: 'string'
+            type: string
           thumbnail:
-            type: 'string'
+            type: string
             nullable: true
           likeCount:
-            type: 'integer'
+            type: integer
           user:
-            type: 'object'
+            type: object
             properties:
               id:
-                type: 'integer'
+                type: integer
               nickname:
-                type: 'string'
+                type: string
               profile_img:
-                type: 'string'
+                type: string
                 nullable: true
           categories:
-            type: 'array'
+            type: array
             items:
-              type: 'object'
+              type: object
               properties:
                 id:
-                  type: 'integer'
+                  type: integer
                 name:
-                  type: 'string'
+                  type: string
       example:
         - id: 1
           created_at: 2022-05-19T14:53:43.044Z
@@ -70,45 +70,45 @@ components:
               name: test2
 
     RequestList:
-      type: 'array'
+      type: array
       items:
-        type: 'object'
+        type: object
         properties:
           id:
-            type: 'integer'
+            type: integer
           created_at:
-            type: 'string'
+            type: string
           updated_at:
-            type: 'string'
+            type: string
           title:
-            type: 'string'
+            type: string
           thumbnail:
-            type: 'string'
+            type: string
             nullable: true
           likeCount:
-            type: 'integer'
+            type: integer
           state:
             type: string
-            enum: ['wait', 'answered']
+            enum: [wait, answered]
           user:
-            type: 'object'
+            type: object
             properties:
               id:
-                type: 'integer'
+                type: integer
               nickname:
-                type: 'string'
+                type: string
               profile_img:
-                type: 'string'
+                type: string
                 nullable: true
           categories:
-            type: 'array'
+            type: array
             items:
-              type: 'object'
+              type: object
               properties:
                 id:
-                  type: 'integer'
+                  type: integer
                 name:
-                  type: 'string'
+                  type: string
       example:
         - id: 1
           created_at: 2022-05-19T14:53:43.044Z

--- a/src/swagger/components/posts.yaml
+++ b/src/swagger/components/posts.yaml
@@ -42,12 +42,12 @@ components:
           created_at: 2022-05-19T14:53:43.044Z
           updated_at: 2022-05-19T14:53:43.044Z
           title: 실험 게시물 제목
-          thumbnail: 실험 게시물 썸네일
+          thumbnail: 실험 게시물 썸네일 url (or null)
           likeCount: 3
           user:
             id: 1
             nickname: test
-            profile_img: null(or img url)
+            profile_img: 프로필 사진 url (or null)
           categories:
             - id: 1
               name: test
@@ -57,12 +57,12 @@ components:
           created_at: 2022-05-19T14:53:43.044Z
           updated_at: 2022-05-19T14:53:43.044Z
           title: 실험 게시물 제목
-          thumbnail: 실험 게시물 썸네일
+          thumbnail: 실험 게시물 썸네일 url (or null)
           likeCount: 3
           user:
             id: 1
             nickname: test
-            profile_img: null(or img url)
+            profile_img: 프로필 사진 url (or null)
           categories:
             - id: 1
               name: test
@@ -114,13 +114,13 @@ components:
           created_at: 2022-05-19T14:53:43.044Z
           updated_at: 2022-05-19T14:53:43.044Z
           title: 의뢰 게시물 제목
-          thumbnail: 의뢰 게시물 썸네일
+          thumbnail: 의뢰 게시물 썸네일 url (or null)
           likeCount: 3
           state: wait (or answered)
           user:
             id: 1
             nickname: test
-            profile_img: null(or imgUrl)
+            profile_img: 프로필 사진 url (or null)
           categories:
             - id: 1
               name: test
@@ -130,13 +130,13 @@ components:
           created_at: 2022-05-19T14:53:43.044Z
           updated_at: 2022-05-19T14:53:43.044Z
           title: 의뢰 게시물 제목
-          thumbnail: 의뢰 게시물 썸네일
+          thumbnail: 의뢰 게시물 썸네일 url (or null)
           likeCount: 3
           state: wait (or answered)
           user:
             id: 1
             nickname: test
-            profile_img: null(or imgUrl)
+            profile_img: 프로필 사진 url (or null)
           categories:
             - id: 1
               name: test

--- a/src/swagger/components/posts.yaml
+++ b/src/swagger/components/posts.yaml
@@ -1,6 +1,6 @@
 components:
   schemas:
-    Experiment:
+    ExperimentList:
       type: 'array'
       items:
         type: 'object'
@@ -69,7 +69,7 @@ components:
             - id: 2
               name: test2
 
-    Request:
+    RequestList:
       type: 'array'
       items:
         type: 'object'

--- a/src/swagger/components/security.yaml
+++ b/src/swagger/components/security.yaml
@@ -1,6 +1,6 @@
 components:
   securitySchemes:
-    sasil-jwt:
+    sasil-access-token:
       description: sasil에서 로그인 후 받은 jwt
       in: header
       name: Authorization

--- a/src/swagger/routes/auth.yaml
+++ b/src/swagger/routes/auth.yaml
@@ -36,13 +36,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '401':
-          description: 인증 오류 (Authorization Header에 인증 토큰 미포함)
+          description: 인증 오류
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         '403':
-          description: 요청 거부 오류 (유효하지 않은 인증 토큰)
+          description: 요청 거부 오류 (권한 없음)
           content:
             application/json:
               schema:

--- a/src/swagger/routes/post.yaml
+++ b/src/swagger/routes/post.yaml
@@ -1,0 +1,513 @@
+tags:
+  - name: Post
+    description: 실험/의뢰 게시물 페이지 관련 API
+
+paths:
+  /post/experiment/{postId}:
+    get:
+      summary: 실험 게시물 정보 조회
+      tags:
+        - Post
+      parameters:
+        - in: path
+          name: postId
+          required: true
+          description: 실험 게시물 id값
+          schema:
+            type: number
+      security:
+        - sasil-access-token: []
+      responses:
+        '200':
+          description: 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExperimentDetail'
+        '400':
+          description: 잘못된 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: 존재하지 않는 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /post/request/{postId}:
+    get:
+      summary: 의뢰 게시물 정보 조회
+      tags:
+        - Post
+      parameters:
+        - in: path
+          name: postId
+          required: true
+          description: 의뢰 게시물 id값
+          schema:
+            type: number
+      security:
+        - sasil-access-token: []
+      responses:
+        '200':
+          description: 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestDetail'
+        '400':
+          description: 잘못된 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: 존재하지 않는 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /post/request/{reqId}/experiments:
+    get:
+      summary: 특정 의뢰에 응답한 실험 게시물 목록 조회
+      tags:
+        - Post
+      parameters:
+        - in: path
+          name: reqId
+          required: true
+          description: 의뢰 게시물 id값
+          schema:
+            type: number
+      responses:
+        '200':
+          description: 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExperimentListByReq'
+        '400':
+          description: 잘못된 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: 존재하지 않는 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /post/experiment/{expId}/request:
+    get:
+      summary: 특정 실험 게시물이 응답한 의뢰 게시물 정보 조회
+      tags:
+        - Post
+      parameters:
+        - in: path
+          name: expId
+          required: true
+          description: 실험 게시물 id값
+          schema:
+            type: number
+      responses:
+        '200':
+          description: 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestForExp'
+        '400':
+          description: 잘못된 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: 존재하지 않는 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /post/{postType}/{postId}/comments:
+    get:
+      summary: 게시물의 댓글 목록 조회 (최신순)
+      tags:
+        - Post
+      parameters:
+        - in: path
+          name: postType
+          required: true
+          description: 게시물 종류
+          schema:
+            type: string
+            enum: ['experiment', 'request']
+        - in: path
+          name: postId
+          required: true
+          description: 게시물 id값
+          schema:
+            type: number
+        - in: query
+          name: display
+          schema:
+            type: integer
+          description: 한 번에 불러올 댓글 갯수 (default '12')
+        - in: query
+          name: page
+          schema:
+            type: integer
+          description: 댓글 페이지 (default '1')
+      responses:
+        '200':
+          description: 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Comments'
+        '400':
+          description: 잘못된 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: 존재하지 않는 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /post/{postType}/{postId}/comment:
+    post:
+      summary: 댓글 작성
+      tags:
+        - Post
+      parameters:
+        - in: path
+          name: postType
+          required: true
+          description: 게시물 종류
+          schema:
+            type: string
+            enum: ['experiment', 'request']
+        - in: path
+          name: postId
+          required: true
+          description: 게시물 id값
+          schema:
+            type: number
+      security:
+        - sasil-access-token: []
+      responses:
+        '200':
+          description: 요청 성공 (body X)
+        '400':
+          description: 잘못된 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: 인증 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: 존재하지 않는 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /post/{postType}/{postId}/comment/{commentId}:
+    delete:
+      summary: 댓글 삭제
+      tags:
+        - Post
+      parameters:
+        - in: path
+          name: postType
+          required: true
+          description: 게시물 종류
+          schema:
+            type: string
+            enum: ['experiment', 'request']
+        - in: path
+          name: postId
+          required: true
+          description: 게시물 id값
+          schema:
+            type: number
+        - in: path
+          name: commentId
+          required: true
+          description: 댓글 id값
+          schema:
+            type: number
+      security:
+        - sasil-access-token: []
+      responses:
+        '200':
+          description: 요청 성공 (body X)
+        '400':
+          description: 잘못된 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: 인증 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: 존재하지 않는 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /post/{postType}/{postId}/like:
+    post:
+      summary: 좋아요 추가
+      tags:
+        - Post
+      parameters:
+        - in: path
+          name: postType
+          required: true
+          description: 게시물 종류
+          schema:
+            type: string
+            enum: ['experiment', 'request']
+        - in: path
+          name: postId
+          required: true
+          description: 게시물 id값
+          schema:
+            type: number
+      security:
+        - sasil-access-token: []
+      responses:
+        '200':
+          description: 요청 성공 (body X)
+        '400':
+          description: 잘못된 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: 인증 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: 존재하지 않는 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    delete:
+      summary: 좋아요 삭제
+      tags:
+        - Post
+      parameters:
+        - in: path
+          name: postType
+          required: true
+          description: 게시물 종류
+          schema:
+            type: string
+            enum: ['experiment', 'request']
+        - in: path
+          name: postId
+          required: true
+          description: 게시물 id값
+          schema:
+            type: number
+      security:
+        - sasil-access-token: []
+      responses:
+        '200':
+          description: 요청 성공 (body X)
+        '400':
+          description: 잘못된 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: 인증 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: 존재하지 않는 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /post/{postType}/{postId}/bookmark:
+    post:
+      summary: 북마크 추가
+      tags:
+        - Post
+      parameters:
+        - in: path
+          name: postType
+          required: true
+          description: 게시물 종류
+          schema:
+            type: string
+            enum: ['experiment', 'request']
+        - in: path
+          name: postId
+          required: true
+          description: 게시물 id값
+          schema:
+            type: number
+      security:
+        - sasil-access-token: []
+      responses:
+        '200':
+          description: 요청 성공 (body X)
+        '400':
+          description: 잘못된 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: 인증 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: 존재하지 않는 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    delete:
+      summary: 북마크 삭제
+      tags:
+        - Post
+      parameters:
+        - in: path
+          name: postType
+          required: true
+          description: 게시물 종류
+          schema:
+            type: string
+            enum: ['experiment', 'request']
+        - in: path
+          name: postId
+          required: true
+          description: 게시물 id값
+          schema:
+            type: number
+      security:
+        - sasil-access-token: []
+      responses:
+        '200':
+          description: 요청 성공 (body X)
+        '400':
+          description: 잘못된 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: 인증 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: 존재하지 않는 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'

--- a/src/swagger/routes/posts.yaml
+++ b/src/swagger/routes/posts.yaml
@@ -1,6 +1,6 @@
 tags:
   - name: Posts
-    description: 게시물 목록 관련 API
+    description: 실험/의뢰 게시물 목록 페이지 관련 API
 
 paths:
   /posts/experiment:
@@ -50,6 +50,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+
   /posts/request:
     get:
       summary: 의뢰 게시물 목록 조회

--- a/src/swagger/routes/posts.yaml
+++ b/src/swagger/routes/posts.yaml
@@ -31,7 +31,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Experiment'
+                $ref: '#/components/schemas/ExperimentList'
         '400':
           description: 잘못된 요청 오류
           content:
@@ -84,7 +84,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Request'
+                $ref: '#/components/schemas/RequestList'
         '400':
           description: 잘못된 요청 오류
           content:

--- a/src/swagger/routes/user.yaml
+++ b/src/swagger/routes/user.yaml
@@ -24,13 +24,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '401':
-          description: 인증 오류 (Authorization Header에 인증 토큰 미포함)
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '403':
-          description: 요청 거부 오류 (유효하지 않은 인증 토큰)
+          description: 인증 오류
           content:
             application/json:
               schema:

--- a/src/swagger/routes/user.yaml
+++ b/src/swagger/routes/user.yaml
@@ -9,7 +9,7 @@ paths:
       tags:
         - User
       security:
-        - sasil-jwt: []
+        - sasil-access-token: []
       responses:
         '200':
           description: 유저 기본 정보 조회 성공


### PR DESCRIPTION
## Issue
#30 

## Description
### 리팩토링
- 실험/의뢰 게시물 페이지에서 사용되는 게시물 북마크 개수 조회의 효율성을 높이기 위한 DB 리팩토링

### PostDetail 페이지에서 사용되는 API 구현
- 게시물 정보 조회 (로그인 [선택])
- 의뢰 게시물에 응답한 실험 게시물 목록 조회 (최신순)
- 실험 게시물이 응답한 의뢰 게시물 조회
- 게시물의 댓글 목록 조회 (최신순)
- 댓글 작성 (로그인)
- 댓글 삭제 (로그인, 본인만)
- 좋아요 (로그인)
- 좋아요 취소 (로그인)
- 북마크 추가 (로그인)
- 북마크 삭제 (로그인)

## Check List
- [x] PR 제목을 commit 규칙에 맞게 작성
- [x] WIP를 붙여야 하는 상황인지 확인
- [x] label 설정
- [x] 작업한 사람 모두를 Assign
- [x] Code Review 요청
