### PR TITLE
feat: add apis for post-write-page

### DIFF
--- a/src/database/controllers/post.ts
+++ b/src/database/controllers/post.ts
@@ -30,16 +30,10 @@ export const getExperimentPost = async (
   const expPostData = await getRepository(ExperimentEntity)
     .createQueryBuilder('experiment')
     .where('experiment.id = :postId', { postId })
-    .select([
-      'experiment',
-      'user.id',
-      'user.nickname',
-      'user.profile_img',
-      'categories.id',
-      'categories.name',
-    ])
+    .select(['experiment', 'user.id', 'user.nickname', 'user.profile_img'])
     .leftJoin('experiment.user', 'user')
-    .leftJoin('experiment.categories', 'categories')
+    .leftJoinAndSelect('experiment.expCategories', 'expCategories')
+    .leftJoinAndSelect('expCategories.category', 'categories')
     .loadRelationCountAndMap('experiment.likeCount', 'experiment.expLikes')
     .loadRelationCountAndMap(
       'experiment.bookmarkCount',
@@ -81,16 +75,10 @@ export const getRequestPost = async (
   const reqPostData = await getRepository(RequestEntity)
     .createQueryBuilder('request')
     .where('request.id = :postId', { postId })
-    .select([
-      'request',
-      'user.id',
-      'user.nickname',
-      'user.profile_img',
-      'categories.id',
-      'categories.name',
-    ])
+    .select(['request', 'user.id', 'user.nickname', 'user.profile_img'])
     .leftJoin('request.user', 'user')
-    .leftJoin('request.categories', 'categories')
+    .leftJoinAndSelect('request.reqCategories', 'reqCategories')
+    .leftJoinAndSelect('reqCategories.category', 'categories')
     .loadRelationCountAndMap('request.likeCount', 'request.reqLikes')
     .loadRelationCountAndMap('request.bookmarkCount', 'request.reqBookmarks')
     .getOne();

--- a/src/database/controllers/post.ts
+++ b/src/database/controllers/post.ts
@@ -1,6 +1,6 @@
 import { getRepository } from 'typeorm';
 
-import { BadRequestError } from '@/errors/customErrors';
+import { BadRequestError, ServerError } from '@/errors/customErrors';
 import ExperimentEntity from '@/database/entity/experiment';
 import RequestEntity from '@/database/entity/request';
 import ReqCommentEntity from '@/database/entity/req-comment';
@@ -10,6 +10,9 @@ import ReqLikeEntity from '@/database/entity/req-like';
 import ExpLikeEntity from '@/database/entity/exp-like';
 import ReqBookmarkEntity from '@/database/entity/req-bookmark';
 import ExpBookmarkEntity from '@/database/entity/exp-bookmark';
+import CategoryEntity from '@/database/entity/category';
+import ReqCategoryEntity from '@/database/entity/req-category';
+import ExpCategoryEntity from '@/database/entity/exp-category';
 
 type PostType = 'experiment' | 'request';
 
@@ -278,7 +281,7 @@ export const deleteComment = async (
     .andWhere(`${entityName}.user_id = :userId`, { userId })
     .execute();
 
-  if (deleteCommResult.affected === 0) {
+  if (deleteCommResult.affected !== 1) {
     throw new BadRequestError(
       '존재하지 않는 게시물/댓글에 대한 요청입니다. (혹은 본인 댓글이 아닙니다.)',
     );
@@ -346,7 +349,7 @@ export const deleteLike = async (
     .andWhere(`${entityName}.user_id = :userId`, { userId })
     .execute();
 
-  if (deleteLikeResult.affected === 0) {
+  if (deleteLikeResult.affected !== 1) {
     throw new BadRequestError('존재하지 않는 게시물에 대한 요청입니다.');
   }
 };
@@ -412,7 +415,203 @@ export const deleteBookmark = async (
     .andWhere(`${entityName}.user_id = :userId`, { userId })
     .execute();
 
-  if (deleteBookmarkResult.affected === 0) {
+  if (deleteBookmarkResult.affected !== 1) {
     throw new BadRequestError('존재하지 않는 게시물에 대한 요청입니다.');
   }
 };
+
+/**
+ * 게시글 추가
+ *
+ * @param postType 게시물 타입 (request | experiment)
+ * @param userId 유저의 id값
+ * @param title 게시물 제목
+ * @param content 게시물 내용
+ * @param thumbnail 게시물 썸네일 (nullable)
+ * @param categories 게시물의 카테고리 배열
+ * @param reqId 실험 게시물이 수행한 의뢰 게시물의 id값
+ */
+export const addPost = async (
+  postType: PostType,
+  userId: number,
+  title: string,
+  content: string,
+  thumbnail: string | undefined,
+  categories: string[],
+  reqId: number | undefined,
+) => {
+  const [PostEntity, PostCategoryEntity, postEntityName, categoryEntityName] = (
+    postType === 'request'
+      ? [RequestEntity, ReqCategoryEntity, 'request', 'req_category']
+      : [ExperimentEntity, ExpCategoryEntity, 'experiment', 'exp_category']
+  ) as any;
+
+  // 유저 정보
+  const newUser = new UserEntity();
+  newUser.id = userId;
+
+  // 게시물 정보
+  const newPost = new PostEntity();
+  newPost.user = newUser;
+  newPost.title = title;
+  newPost.content = content;
+
+  if (thumbnail) {
+    newPost.thumbnail = thumbnail;
+  }
+
+  // 실험 게시물 작성글이면서, 선택한 의뢰 게시물이 있는 경우
+  if (postType === 'experiment' && reqId) {
+    const reqPost = await getRepository(RequestEntity)
+      .createQueryBuilder('request')
+      .where('request.id = :reqId', { reqId })
+      .select(['request.id', 'request.state'])
+      .getOne();
+
+    // 선택된 의뢰 게시물의 state가 'wait'인 경우, 'answered'로 변경
+    if (reqPost?.state === 'wait') {
+      const editRequStateResult = await getRepository(RequestEntity)
+        .createQueryBuilder('request')
+        .update()
+        .set({ state: 'answered' })
+        .where('request.id = :reqId', { reqId })
+        .execute();
+
+      if (editRequStateResult.affected !== 1) {
+        throw new BadRequestError(
+          '존재하지 않는 실험 게시물에 대한 요청입니다.',
+        );
+      }
+    }
+
+    newPost.request = reqPost;
+  }
+
+  const insertPostResult = await getRepository(PostEntity)
+    .createQueryBuilder()
+    .insert()
+    .into(postEntityName)
+    .values(newPost)
+    .updateEntity(false)
+    .execute();
+
+  const postId = insertPostResult.raw.insertId; // insert 후, 해당 id값
+
+  // 카테고리 처리 로직
+  if (categories.length > 0) {
+    categories.forEach(async (category) => {
+      // 카테고리 이름으로 조회
+      const categoryData = await getRepository(CategoryEntity)
+        .createQueryBuilder('category')
+        .where('category.name = :category', { category })
+        .select()
+        .getOne();
+
+      let categoryId = categoryData?.id;
+
+      // 없으면 추가
+      if (!categoryData) {
+        const insertCategoryResult = await getRepository(CategoryEntity)
+          .createQueryBuilder()
+          .insert()
+          .into('category')
+          .values({ name: category })
+          .updateEntity(false)
+          .execute();
+
+        categoryId = insertCategoryResult.raw.insertId;
+      }
+
+      // 게시물-카테고리 추가
+      if (!categoryId || !postId) {
+        throw new ServerError(
+          '카테고리 혹은 게시물 데이터가 정상적으로 생성되지 않았습니다.',
+        );
+      }
+
+      const newCategory = new CategoryEntity();
+      newCategory.id = categoryId;
+
+      newPost.id = postId;
+
+      const newPostCategory = new PostCategoryEntity();
+      newPostCategory.category = newCategory;
+      newPostCategory[postEntityName] = newPost;
+
+      await getRepository(PostCategoryEntity)
+        .createQueryBuilder()
+        .insert()
+        .into(categoryEntityName)
+        .values(newPostCategory)
+        .updateEntity(false)
+        .execute();
+    });
+  }
+};
+
+// TODO: 삭제
+// /**
+//  * 게시글 삭제
+//  *
+//  * @param postType 게시물 타입 (request | experiment)
+//  * @param postId 게시물 id값
+//  * @param userId 유저의 id값
+//  */
+// export const deletePost = async (
+//   postType: PostType,
+//   postId: number,
+//   userId: number,
+// ) => {
+//   const [PostEntity, entityName, entityId] =
+//     postType === 'request'
+//       ? [RequestEntity, 'request', 'req_id']
+//       : [ExperimentEntity, 'experiment', 'exp_id'];
+
+//   const deletePostResult = await getRepository(PostEntity)
+//     .createQueryBuilder(entityName)
+//     .delete()
+//     .where(`${entityName}.id = :postId`, { postId })
+//     .andWhere(`${entityName}.user_id = :userId`, { userId })
+//     .execute();
+
+//   if (deletePostResult.affected !== 1) {
+//     throw new BadRequestError(
+//       '존재하지 않는 게시물에 대한 요청입니다. (혹은 본인 게시물이 아닙니다.)',
+//     );
+//   }
+// };
+
+// TODO: 수정
+// /**
+//  * 게시글 수정
+//  *
+//  * @param postType 게시물 타입 (request | experiment)
+//  * @param postId 게시물 id값
+//  * @param userId 유저의 id값
+//  */
+// export const editPost = async (
+//   postType: PostType,
+//   postId: number,
+//   userId: number,
+//   title: string,
+//   content: string,
+//   thumbnail: string | undefined,
+//   reqId: number | undefined,
+// ) => {
+//   const [PostEntity, entityName, entityId] =
+//     postType === 'request'
+//       ? [RequestEntity, 'request', 'req_id']
+//       : [ExperimentEntity, 'experiment', 'exp_id'];
+
+//   const editRequStateResult = await getRepository(PostEntity)
+//     .createQueryBuilder(entityName)
+//     .update()
+//     .set({ title, content, thumbnail })
+//     .where(`${entityName}.id = :postId`, { postId })
+//     .andWhere(`${entityName}.user_id = :userId`, { userId })
+//     .execute();
+
+//   if (editRequStateResult.affected !== 1) {
+//     throw new BadRequestError('존재하지 않는 실험 게시물에 대한 요청입니다.');
+//   }
+// };

--- a/src/database/controllers/post.ts
+++ b/src/database/controllers/post.ts
@@ -30,13 +30,13 @@ export const getExperimentPost = async (
   const expPostData = await getRepository(ExperimentEntity)
     .createQueryBuilder('experiment')
     .where('experiment.id = :postId', { postId })
-    .select(['experiment', 'user.id', 'user.nickname', 'user.profile_img'])
+    .select(['experiment', 'user.id', 'user.nickname', 'user.profileImg'])
     .leftJoin('experiment.user', 'user')
     .leftJoinAndSelect('experiment.expCategories', 'expCategories')
     .leftJoinAndSelect('expCategories.category', 'categories')
-    .loadRelationCountAndMap('experiment.like_count', 'experiment.expLikes')
+    .loadRelationCountAndMap('experiment.likeCount', 'experiment.expLikes')
     .loadRelationCountAndMap(
-      'experiment.bookmark_count',
+      'experiment.bookmarkCount',
       'experiment.expBookmarks',
     )
     .getOne();
@@ -63,16 +63,16 @@ export const getExperimentPost = async (
     : false;
 
   const { expCategories, ...data } = expPostData;
-  const categoriesData = expCategories.map((categoryData) => ({
+  const categories = expCategories.map((categoryData) => ({
     id: categoryData.category.id,
     name: categoryData.category.name,
   }));
 
   const result = {
     ...data,
-    categories: categoriesData,
-    is_like: isLike,
-    is_bookmark: isBookmark,
+    isLike,
+    isBookmark,
+    categories,
   };
 
   return result;
@@ -92,12 +92,12 @@ export const getRequestPost = async (
   const reqPostData = await getRepository(RequestEntity)
     .createQueryBuilder('request')
     .where('request.id = :postId', { postId })
-    .select(['request', 'user.id', 'user.nickname', 'user.profile_img'])
+    .select(['request', 'user.id', 'user.nickname', 'user.profileImg'])
     .leftJoin('request.user', 'user')
     .leftJoinAndSelect('request.reqCategories', 'reqCategories')
     .leftJoinAndSelect('reqCategories.category', 'categories')
-    .loadRelationCountAndMap('request.like_count', 'request.reqLikes')
-    .loadRelationCountAndMap('request.bookmark_count', 'request.reqBookmarks')
+    .loadRelationCountAndMap('request.likeCount', 'request.reqLikes')
+    .loadRelationCountAndMap('request.bookmarkCount', 'request.reqBookmarks')
     .getOne();
 
   if (!reqPostData) {
@@ -121,16 +121,16 @@ export const getRequestPost = async (
     : false;
 
   const { reqCategories, ...data } = reqPostData;
-  const categoriesData = reqCategories.map((categoryData) => ({
+  const categories = reqCategories.map((categoryData) => ({
     id: categoryData.category.id,
     name: categoryData.category.name,
   }));
 
   const result = {
     ...data,
-    categories: categoriesData,
-    is_like: isLike,
-    is_bookmark: isBookmark,
+    isLike,
+    isBookmark,
+    categories,
   };
 
   return result;
@@ -143,23 +143,23 @@ export const getRequestPost = async (
  * @returns experiment posts list
  */
 export const getExpListByReqId = async (reqId: number) => {
-  const sortType = 'experiment.created_at';
+  const sortType = 'experiment.createdAt';
 
   const expPostList = await getRepository(ExperimentEntity)
     .createQueryBuilder('experiment')
     .where('experiment.req_id = :reqId', { reqId })
     .select([
       'experiment.id',
-      'experiment.created_at',
-      'experiment.updated_at',
+      'experiment.createdAt',
+      'experiment.updatedAt',
       'experiment.title',
       'experiment.thumbnail',
       'user.id',
       'user.nickname',
-      'user.profile_img',
+      'user.profileImg',
     ])
     .leftJoin('experiment.user', 'user')
-    .loadRelationCountAndMap('experiment.like_count', 'experiment.expLikes')
+    .loadRelationCountAndMap('experiment.likeCount', 'experiment.expLikes')
     .orderBy(`${sortType}`, 'DESC')
     .getMany();
 
@@ -179,18 +179,18 @@ export const getReqPostByExpId = async (expId: number) => {
     .select([
       'experiment.id',
       'request.id',
-      'request.created_at',
-      'request.updated_at',
+      'request.createdAt',
+      'request.updatedAt',
       'request.title',
       'request.thumbnail',
       'user.id',
       'user.nickname',
-      'user.profile_img',
+      'user.profileImg',
     ])
     .leftJoin('experiment.request', 'request')
     .leftJoin('request.user', 'user')
-    .loadRelationCountAndMap('request.like_count', 'request.reqLikes')
-    .loadRelationCountAndMap('request.bookmark_count', 'request.reqBookmarks')
+    .loadRelationCountAndMap('request.likeCount', 'request.reqLikes')
+    .loadRelationCountAndMap('request.bookmarkCount', 'request.reqBookmarks')
     .getOne();
 
   return reqPost?.request;
@@ -216,7 +216,7 @@ export const getComments = async (
       ? [ReqCommentEntity, 'req_comment', 'req_id']
       : [ExpCommentEntity, 'exp_comment', 'exp_id'];
 
-  const sortType = `${entityName}.created_at`;
+  const sortType = `${entityName}.createdAt`;
 
   const commentsData = await getRepository(TargetEntity)
     .createQueryBuilder(entityName)
@@ -225,7 +225,7 @@ export const getComments = async (
       `${entityName}`,
       'commWriter.id',
       'commWriter.nickname',
-      'commWriter.profile_img',
+      'commWriter.profileImg',
     ])
     .orderBy(sortType, 'DESC')
     .offset((page - 1) * display)

--- a/src/database/controllers/posts.ts
+++ b/src/database/controllers/posts.ts
@@ -39,8 +39,6 @@ const getExperimentList = async (
       'user.id',
       'user.nickname',
       'user.profile_img',
-      'categories.id',
-      'categories.name',
     ])
     .innerJoin(
       (qb) =>
@@ -56,7 +54,8 @@ const getExperimentList = async (
       'topExps.subexp_id = experiment.id',
     )
     .leftJoin('experiment.user', 'user')
-    .leftJoin('experiment.categories', 'categories')
+    .leftJoinAndSelect('experiment.expCategories', 'expCategories')
+    .leftJoinAndSelect('expCategories.category', 'categories')
     .loadRelationCountAndMap('experiment.likeCount', 'experiment.expLikes')
     .orderBy(sortType[sort].second, 'DESC')
     .getMany();
@@ -112,8 +111,6 @@ const getRequestList = async (
       'user.id',
       'user.nickname',
       'user.profile_img',
-      'categories.id',
-      'categories.name',
     ])
     .innerJoin(
       (qb) =>
@@ -132,7 +129,8 @@ const getRequestList = async (
       'topReqs.subreq_id = request.id',
     )
     .leftJoin('request.user', 'user')
-    .leftJoin('request.categories', 'categories')
+    .leftJoinAndSelect('request.reqCategories', 'reqCategories')
+    .leftJoinAndSelect('reqCategories.category', 'categories')
     .loadRelationCountAndMap('request.likeCount', 'request.reqLikes')
     .orderBy(sortType[sort].second, 'DESC')
     .getMany();

--- a/src/database/controllers/posts.ts
+++ b/src/database/controllers/posts.ts
@@ -19,8 +19,8 @@ const getExperimentList = async (
 ) => {
   const sortType = {
     popular: {
-      first: 'likeCount',
-      second: 'topExps.likeCount',
+      first: 'like_count',
+      second: 'topExps.like_count',
     },
     recent: {
       first: 'subexp.created_at',
@@ -43,7 +43,7 @@ const getExperimentList = async (
     .innerJoin(
       (qb) =>
         qb
-          .select(['subexp.id', 'COUNT(likes.id) as likeCount'])
+          .select(['subexp.id', 'COUNT(likes.id) as like_count'])
           .from(ExperimentEntity, 'subexp')
           .leftJoin('subexp.expLikes', 'likes')
           .groupBy('subexp.id')
@@ -55,8 +55,8 @@ const getExperimentList = async (
     )
     .leftJoin('experiment.user', 'user')
     .leftJoinAndSelect('experiment.expCategories', 'expCategories')
-    .leftJoinAndSelect('expCategories.category', 'categories')
-    .loadRelationCountAndMap('experiment.likeCount', 'experiment.expLikes')
+    .leftJoinAndSelect('expCategories.category', 'category')
+    .loadRelationCountAndMap('experiment.like_count', 'experiment.expLikes')
     .orderBy(sortType[sort].second, 'DESC')
     .getMany();
 
@@ -64,7 +64,18 @@ const getExperimentList = async (
     throw new ServerError('DB에서 expListData 조회를 실패하였습니다.');
   }
 
-  return expListData;
+  const result = expListData.map((expData) => {
+    const { expCategories, ...data } = expData;
+
+    const categoriesData = expCategories.map((categoryData) => ({
+      id: categoryData.category.id,
+      name: categoryData.category.name,
+    }));
+
+    return { ...data, categories: categoriesData };
+  });
+
+  return result;
 };
 
 /**
@@ -84,8 +95,8 @@ const getRequestList = async (
 ) => {
   const sortType = {
     popular: {
-      first: 'likeCount',
-      second: 'topReqs.likeCount',
+      first: 'like_count',
+      second: 'topReqs.like_count',
     },
     recent: {
       first: 'subreq.created_at',
@@ -115,7 +126,7 @@ const getRequestList = async (
     .innerJoin(
       (qb) =>
         qb
-          .select(['subreq.id', 'COUNT(likes.id) as likeCount'])
+          .select(['subreq.id', 'COUNT(likes.id) as like_count'])
           .from(RequestEntity, 'subreq')
           .where('subreq.state != :reverseState ', {
             reverseState: reverseState[state],
@@ -130,8 +141,8 @@ const getRequestList = async (
     )
     .leftJoin('request.user', 'user')
     .leftJoinAndSelect('request.reqCategories', 'reqCategories')
-    .leftJoinAndSelect('reqCategories.category', 'categories')
-    .loadRelationCountAndMap('request.likeCount', 'request.reqLikes')
+    .leftJoinAndSelect('reqCategories.category', 'category')
+    .loadRelationCountAndMap('request.like_count', 'request.reqLikes')
     .orderBy(sortType[sort].second, 'DESC')
     .getMany();
 
@@ -139,7 +150,18 @@ const getRequestList = async (
     throw new ServerError('DB에서 reqListData 조회를 실패하였습니다.');
   }
 
-  return reqListData;
+  const result = reqListData.map((expData) => {
+    const { reqCategories, ...data } = expData;
+
+    const categoriesData = reqCategories.map((categoryData) => ({
+      id: categoryData.category.id,
+      name: categoryData.category.name,
+    }));
+
+    return { ...data, categories: categoriesData };
+  });
+
+  return result;
 };
 
 export { getExperimentList, getRequestList };

--- a/src/database/controllers/posts.ts
+++ b/src/database/controllers/posts.ts
@@ -19,12 +19,12 @@ const getExperimentList = async (
 ) => {
   const sortType = {
     popular: {
-      first: 'like_count',
-      second: 'topExps.like_count',
+      first: 'likeCount',
+      second: 'topExps.likeCount',
     },
     recent: {
-      first: 'subexp.created_at',
-      second: 'experiment.created_at',
+      first: 'subexp.createdAt',
+      second: 'experiment.createdAt',
     },
   };
 
@@ -32,18 +32,18 @@ const getExperimentList = async (
     .createQueryBuilder('experiment')
     .select([
       'experiment.id',
-      'experiment.created_at',
-      'experiment.updated_at',
+      'experiment.createdAt',
+      'experiment.updatedAt',
       'experiment.title',
       'experiment.thumbnail',
       'user.id',
       'user.nickname',
-      'user.profile_img',
+      'user.profileImg',
     ])
     .innerJoin(
       (qb) =>
         qb
-          .select(['subexp.id', 'COUNT(likes.id) as like_count'])
+          .select(['subexp.id', 'COUNT(likes.id) as likeCount'])
           .from(ExperimentEntity, 'subexp')
           .leftJoin('subexp.expLikes', 'likes')
           .groupBy('subexp.id')
@@ -56,7 +56,7 @@ const getExperimentList = async (
     .leftJoin('experiment.user', 'user')
     .leftJoinAndSelect('experiment.expCategories', 'expCategories')
     .leftJoinAndSelect('expCategories.category', 'category')
-    .loadRelationCountAndMap('experiment.like_count', 'experiment.expLikes')
+    .loadRelationCountAndMap('experiment.likeCount', 'experiment.expLikes')
     .orderBy(sortType[sort].second, 'DESC')
     .getMany();
 
@@ -67,12 +67,12 @@ const getExperimentList = async (
   const result = expListData.map((expData) => {
     const { expCategories, ...data } = expData;
 
-    const categoriesData = expCategories.map((categoryData) => ({
+    const categories = expCategories.map((categoryData) => ({
       id: categoryData.category.id,
       name: categoryData.category.name,
     }));
 
-    return { ...data, categories: categoriesData };
+    return { ...data, categories };
   });
 
   return result;
@@ -95,12 +95,12 @@ const getRequestList = async (
 ) => {
   const sortType = {
     popular: {
-      first: 'like_count',
-      second: 'topReqs.like_count',
+      first: 'likeCount',
+      second: 'topReqs.likeCount',
     },
     recent: {
-      first: 'subreq.created_at',
-      second: 'request.created_at',
+      first: 'subreq.createdAt',
+      second: 'request.createdAt',
     },
   };
 
@@ -114,19 +114,19 @@ const getRequestList = async (
     .createQueryBuilder('request')
     .select([
       'request.id',
-      'request.created_at',
-      'request.updated_at',
+      'request.createdAt',
+      'request.updatedAt',
       'request.title',
       'request.thumbnail',
       'request.state',
       'user.id',
       'user.nickname',
-      'user.profile_img',
+      'user.profileImg',
     ])
     .innerJoin(
       (qb) =>
         qb
-          .select(['subreq.id', 'COUNT(likes.id) as like_count'])
+          .select(['subreq.id', 'COUNT(likes.id) as likeCount'])
           .from(RequestEntity, 'subreq')
           .where('subreq.state != :reverseState ', {
             reverseState: reverseState[state],
@@ -142,7 +142,7 @@ const getRequestList = async (
     .leftJoin('request.user', 'user')
     .leftJoinAndSelect('request.reqCategories', 'reqCategories')
     .leftJoinAndSelect('reqCategories.category', 'category')
-    .loadRelationCountAndMap('request.like_count', 'request.reqLikes')
+    .loadRelationCountAndMap('request.likeCount', 'request.reqLikes')
     .orderBy(sortType[sort].second, 'DESC')
     .getMany();
 
@@ -153,12 +153,12 @@ const getRequestList = async (
   const result = reqListData.map((expData) => {
     const { reqCategories, ...data } = expData;
 
-    const categoriesData = reqCategories.map((categoryData) => ({
+    const categories = reqCategories.map((categoryData) => ({
       id: categoryData.category.id,
       name: categoryData.category.name,
     }));
 
-    return { ...data, categories: categoriesData };
+    return { ...data, categories };
   });
 
   return result;

--- a/src/database/controllers/user.ts
+++ b/src/database/controllers/user.ts
@@ -61,7 +61,7 @@ export const addUser = async (
 
   const newUserData = userRepository.create({
     email,
-    login_type: loginType,
+    loginType,
     nickname, // TODO: random 생성
   });
 

--- a/src/database/entity/basic-entity.ts
+++ b/src/database/entity/basic-entity.ts
@@ -9,10 +9,10 @@ abstract class BasicEntity {
   id!: number;
 
   @CreateDateColumn({ name: 'created_at' })
-  created_at!: Date;
+  createdAt!: Date;
 
   @UpdateDateColumn({ name: 'updated_at' })
-  updated_at!: Date;
+  updatedAt!: Date;
 }
 
 export default BasicEntity;

--- a/src/database/entity/category.ts
+++ b/src/database/entity/category.ts
@@ -1,40 +1,22 @@
 /* eslint-disable import/no-cycle */
-import { Entity, Column, ManyToMany, JoinTable } from 'typeorm';
+import { Entity, Column, OneToMany } from 'typeorm';
 
 import BasicEntity from './basic-entity';
-import Request from './request';
-import Experiment from './experiment';
+import ReqCategory from './req-category';
+import ExpCategory from './exp-category';
 
 @Entity()
 class Category extends BasicEntity {
   @Column('varchar', { length: 30 })
   name!: string;
 
-  // Category:Request = M:N -> req_category
-  @ManyToMany(() => Request, (request) => request.categories)
-  @JoinTable({
-    name: 'req_category',
-    joinColumn: {
-      name: 'category_id',
-    },
-    inverseJoinColumn: {
-      name: 'req_id',
-    },
-  })
-  requests!: Request[];
+  // Category:ReqCategory = 1:N
+  @OneToMany(() => ReqCategory, (reqCategory) => reqCategory.category)
+  reqCategories!: ReqCategory[];
 
-  // Category:Exp = M:N -> exp_category
-  @ManyToMany(() => Experiment, (experiment) => experiment.categories)
-  @JoinTable({
-    name: 'exp_category',
-    joinColumn: {
-      name: 'category_id',
-    },
-    inverseJoinColumn: {
-      name: 'exp_id',
-    },
-  })
-  experiments!: Experiment;
+  // Category:ExpCategory = 1:N
+  @OneToMany(() => ExpCategory, (expCategory) => expCategory.category)
+  expCategories!: ExpCategory[];
 }
 
 export default Category;

--- a/src/database/entity/exp-category.ts
+++ b/src/database/entity/exp-category.ts
@@ -1,0 +1,25 @@
+/* eslint-disable import/no-cycle */
+import { Entity, ManyToOne, JoinColumn, PrimaryGeneratedColumn } from 'typeorm';
+
+import Cateogry from './category';
+import Experiment from './experiment';
+
+@Entity()
+class ExpCategory {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @ManyToOne(() => Cateogry, (category) => category.expCategories)
+  @JoinColumn({
+    name: 'category_id',
+  })
+  category!: Cateogry;
+
+  @ManyToOne(() => Experiment, (experiment) => experiment.expCategories)
+  @JoinColumn({
+    name: 'exp_id',
+  })
+  experiment!: Experiment;
+}
+
+export default ExpCategory;

--- a/src/database/entity/exp-comment.ts
+++ b/src/database/entity/exp-comment.ts
@@ -10,8 +10,8 @@ class ExpComment extends BasicEntity {
   @Column('text')
   content!: string;
 
-  @Column('int', { nullable: true })
-  parent_id!: number;
+  @Column('int', { name: 'parent_id', nullable: true })
+  parentId!: number;
 
   // ExpComment:User = N:1
   @ManyToOne(() => User, (user) => user.expComments)

--- a/src/database/entity/experiment.ts
+++ b/src/database/entity/experiment.ts
@@ -1,12 +1,5 @@
 /* eslint-disable import/no-cycle */
-import {
-  Entity,
-  Column,
-  ManyToOne,
-  ManyToMany,
-  OneToMany,
-  JoinColumn,
-} from 'typeorm';
+import { Entity, Column, ManyToOne, OneToMany, JoinColumn } from 'typeorm';
 
 import BasicEntity from './basic-entity';
 import User from './user';
@@ -14,7 +7,7 @@ import Request from './request';
 import ExpComment from './exp-comment';
 import ExpLike from './exp-like';
 import ExpBookmark from './exp-bookmark';
-import Category from './category';
+import ExpCategory from './exp-category';
 
 @Entity()
 class Experiment extends BasicEntity {
@@ -49,13 +42,13 @@ class Experiment extends BasicEntity {
   @OneToMany(() => ExpLike, (expLike) => expLike.experiment)
   expLikes!: ExpLike[];
 
-  // Exp:ExpBookmark = M:N -> exp_bookmark
+  // Exp:ExpBookmark = 1:N
   @OneToMany(() => ExpBookmark, (expBookmark) => expBookmark.experiment)
   expBookmarks!: ExpBookmark[];
 
-  // Exp:Category = M:N -> exp_category
-  @ManyToMany(() => Category, (category) => category.experiments)
-  categories!: Category[];
+  // Exp:ExpCategory = 1:N
+  @OneToMany(() => ExpCategory, (expCategory) => expCategory.experiment)
+  expCategories!: ExpCategory[];
 }
 
 export default Experiment;

--- a/src/database/entity/notification.ts
+++ b/src/database/entity/notification.ts
@@ -6,14 +6,17 @@ import User from './user';
 
 @Entity()
 class Notification extends BasicEntity {
-  @Column({ type: 'enum', enum: ['exp', 'req', 'req-exp', 'recomment'] })
-  noti_type!: string;
+  @Column('enum', {
+    name: 'noti_type',
+    enum: ['exp', 'req', 'req-exp', 'recomment'],
+  })
+  notiType!: string;
 
-  @Column('int', { nullable: true })
+  @Column('int', { name: 'post_id', nullable: true })
   postId!: string;
 
-  @Column({ type: 'enum', enum: ['exp', 'req'] })
-  post_type!: string;
+  @Column('enum', { name: 'post_type', enum: ['exp', 'req'] })
+  postType!: string;
 
   // Notification:User = N:1 -> sender_id
   @ManyToOne(() => User, (user) => user.sendNotifications)

--- a/src/database/entity/req-category.ts
+++ b/src/database/entity/req-category.ts
@@ -1,0 +1,25 @@
+/* eslint-disable import/no-cycle */
+import { Entity, ManyToOne, JoinColumn, PrimaryGeneratedColumn } from 'typeorm';
+
+import Cateogry from './category';
+import Request from './request';
+
+@Entity()
+class ReqCategory {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @ManyToOne(() => Cateogry, (category) => category.reqCategories)
+  @JoinColumn({
+    name: 'category_id',
+  })
+  category!: Cateogry;
+
+  @ManyToOne(() => Request, (request) => request.reqCategories)
+  @JoinColumn({
+    name: 'req_id',
+  })
+  request!: Request;
+}
+
+export default ReqCategory;

--- a/src/database/entity/req-comment.ts
+++ b/src/database/entity/req-comment.ts
@@ -10,8 +10,8 @@ class ReqComment extends BasicEntity {
   @Column('text')
   content!: string;
 
-  @Column('int', { nullable: true })
-  parent_id!: number;
+  @Column('int', { name: 'parent_id', nullable: true })
+  parentId!: number;
 
   // ReqComment:User = N:1
   @ManyToOne(() => User, (user) => user.reqComments)

--- a/src/database/entity/request.ts
+++ b/src/database/entity/request.ts
@@ -1,12 +1,5 @@
 /* eslint-disable import/no-cycle */
-import {
-  Entity,
-  Column,
-  ManyToOne,
-  OneToMany,
-  ManyToMany,
-  JoinColumn,
-} from 'typeorm';
+import { Entity, Column, ManyToOne, OneToMany, JoinColumn } from 'typeorm';
 
 import BasicEntity from './basic-entity';
 import User from './user';
@@ -14,7 +7,7 @@ import Experiment from './experiment';
 import ReqComment from './req-comment';
 import ReqLike from './req-like';
 import ReqBookmark from './req-bookmark';
-import Category from './category';
+import ReqCategory from './req-category';
 
 @Entity()
 class Request extends BasicEntity {
@@ -53,9 +46,9 @@ class Request extends BasicEntity {
   @OneToMany(() => ReqBookmark, (reqBookmark) => reqBookmark.request)
   reqBookmarks!: ReqBookmark[];
 
-  // Request:Category = M:N -> req_category
-  @ManyToMany(() => Category, (category) => category.requests) // req_category
-  categories!: Category[];
+  // Request:ReqCategory = 1:N
+  @OneToMany(() => ReqCategory, (reqCategory) => reqCategory.request)
+  reqCategories!: ReqCategory[];
 }
 
 export default Request;

--- a/src/database/entity/request.ts
+++ b/src/database/entity/request.ts
@@ -20,7 +20,7 @@ class Request extends BasicEntity {
   @Column('varchar', { length: 255, nullable: true })
   thumbnail!: string;
 
-  @Column({ type: 'enum', enum: ['wait', 'answered'], default: 'wait' })
+  @Column('enum', { enum: ['wait', 'answered'], default: 'wait' })
   state!: 'wait' | 'answered';
 
   // Request:User = N:1

--- a/src/database/entity/user.ts
+++ b/src/database/entity/user.ts
@@ -19,14 +19,14 @@ class User extends BasicEntity {
   @Column('varchar', { length: 255 })
   email!: string;
 
-  @Column({ type: 'enum', enum: ['kakao', 'google', 'apple'] })
-  login_type!: LoginTypes;
+  @Column('enum', { name: 'login_type', enum: ['kakao', 'google', 'apple'] })
+  loginType!: LoginTypes;
 
   @Column('varchar', { length: 30 })
   nickname!: string;
 
-  @Column('varchar', { length: 255, nullable: true })
-  profile_img!: string;
+  @Column('varchar', { name: 'profile_img', length: 255, nullable: true })
+  profileImg!: string;
 
   // User:Exp = 1:N
   @OneToMany(() => Experiment, (experiment) => experiment.user)

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -11,15 +11,16 @@ export const checkLoggedIn = wrapAsync(
   async (req: Request, res: Response, next: NextFunction) => {
     const token = req.headers.authorization;
 
-    if (token) {
-      const userId = await jwtVerify(token);
-      req.userId = userId;
-      next();
-    } else {
+    if (!token) {
       throw new UnauthorizedError(
         '요청의 Authorization Header에 JWT 토큰이 포함되어 있지 않습니다.',
       );
     }
+
+    const userId = await jwtVerify(token);
+    req.userId = userId;
+
+    next();
   },
 );
 

--- a/src/routes/post.ts
+++ b/src/routes/post.ts
@@ -18,6 +18,7 @@ import {
   deleteLike,
   addBookmark,
   deleteBookmark,
+  addPost,
 } from '@/database/controllers/post';
 import { checkLoggedIn, getUserId } from './middleware';
 
@@ -265,5 +266,40 @@ router.delete(
     res.end();
   }),
 );
+
+// 게시글 추가
+router.post(
+  '/:postType',
+  checkLoggedIn,
+  wrapAsync(async (req: Request, res: Response) => {
+    const { postType } = req.params;
+    const { title, content, thumbnail, categories, reqId } = req.body;
+    const { userId } = req;
+
+    if (!(postType === 'experiment' || postType === 'request')) {
+      throw new NotFoundError('잘못된 postType을 포함한 요청입니다.');
+    }
+
+    if (!userId) {
+      throw new UnauthorizedError('로그인이 필요한 요청입니다.');
+    }
+
+    await addPost(
+      postType,
+      userId,
+      title,
+      content,
+      thumbnail,
+      categories,
+      reqId,
+    );
+
+    res.end();
+  }),
+);
+
+// 게시글 삭제
+
+// 게시글 수정
 
 export default router;

--- a/src/routes/post.ts
+++ b/src/routes/post.ts
@@ -21,6 +21,7 @@ import {
   addPost,
 } from '@/database/controllers/post';
 import { checkLoggedIn, getUserId } from './middleware';
+import { getImgUploadURL } from '@/utils/uploadImage';
 
 const router = express.Router();
 
@@ -295,6 +296,17 @@ router.post(
     );
 
     res.end();
+  }),
+);
+
+// 이미지 업로드 URL 반환
+router.get(
+  '/:image',
+  checkLoggedIn,
+  wrapAsync(async (req: Request, res: Response) => {
+    const imgUploadURL = await getImgUploadURL();
+
+    return res.json(imgUploadURL);
   }),
 );
 

--- a/src/swagger/components/errors.yaml
+++ b/src/swagger/components/errors.yaml
@@ -1,7 +1,8 @@
 components:
   schemas:
-    Error:
-      type: 'object'
-      properties:
-        msg:
-          type: 'string'
+    responseBodies:
+      Error:
+        type: 'object'
+        properties:
+          msg:
+            type: 'string'

--- a/src/swagger/components/post.yaml
+++ b/src/swagger/components/post.yaml
@@ -1,140 +1,189 @@
 components:
   schemas:
-    ExperimentDetail:
-      type: object
-      properties:
-        id:
-          type: integer
-        created_at:
-          type: string
-        updated_at:
-          type: string
-        title:
-          type: string
-        content:
-          type: string
-        thumbnail:
-          type: string
-          nullable: true
-        likeCount:
-          type: integer
-        bookmarkCount:
-          type: integer
-        isLike:
-          type: boolean
-        isBookmark:
-          type: boolean
-        user:
-          type: object
-          properties:
-            id:
-              type: integer
-            nickname:
-              type: string
-            profile_img:
-              type: string
-              nullable: true
-        categories:
-          type: array
-          items:
+    responseBodies:
+      ExperimentDetail:
+        type: object
+        properties:
+          id:
+            type: integer
+          created_at:
+            type: string
+          updated_at:
+            type: string
+          title:
+            type: string
+          content:
+            type: string
+          thumbnail:
+            type: string
+            nullable: true
+          likeCount:
+            type: integer
+          bookmarkCount:
+            type: integer
+          isLike:
+            type: boolean
+          isBookmark:
+            type: boolean
+          user:
             type: object
             properties:
               id:
                 type: integer
-              name:
+              nickname:
                 type: string
-      example:
-        id: 1
-        created_at: 2022-05-19T14:53:43.044Z
-        updated_at: 2022-05-19T14:53:43.044Z
-        title: 실험 게시물 제목
-        content: 게시물 내용
-        thumbnail: 실험 게시물 썸네일 url (or null)
-        likeCount: 3
-        bookmarkCount: 2
-        isLike: true
-        isBookmark: false
-        user:
+              profile_img:
+                type: string
+                nullable: true
+          categories:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type: integer
+                name:
+                  type: string
+        example:
           id: 1
-          nickname: test
-          profile_img: 프로필 사진 url (or null)
-        categories:
-          - id: 1
-            name: test
-          - id: 2
-            name: test2
+          created_at: 2022-05-19T14:53:43.044Z
+          updated_at: 2022-05-19T14:53:43.044Z
+          title: 실험 게시물 제목
+          content: 게시물 내용
+          thumbnail: 실험 게시물 썸네일 url (or null)
+          likeCount: 3
+          bookmarkCount: 2
+          isLike: true
+          isBookmark: false
+          user:
+            id: 1
+            nickname: test
+            profile_img: 프로필 사진 url (or null)
+          categories:
+            - id: 1
+              name: test
+            - id: 2
+              name: test2
 
-    RequestDetail:
-      type: object
-      properties:
-        id:
-          type: integer
-        created_at:
-          type: string
-        updated_at:
-          type: string
-        title:
-          type: string
-        content:
-          type: string
-        thumbnail:
-          type: string
-          nullable: true
-        likeCount:
-          type: integer
-        bookmarkCount:
-          type: integer
-        isLike:
-          type: boolean
-        isBookmark:
-          type: boolean
-        state:
-          type: string
-          enum: ['wait', 'answered']
-        user:
-          type: object
-          properties:
-            id:
-              type: integer
-            nickname:
-              type: string
-            profile_img:
-              type: string
-              nullable: true
-        categories:
-          type: array
-          items:
+      RequestDetail:
+        type: object
+        properties:
+          id:
+            type: integer
+          created_at:
+            type: string
+          updated_at:
+            type: string
+          title:
+            type: string
+          content:
+            type: string
+          thumbnail:
+            type: string
+            nullable: true
+          likeCount:
+            type: integer
+          bookmarkCount:
+            type: integer
+          isLike:
+            type: boolean
+          isBookmark:
+            type: boolean
+          state:
+            type: string
+            enum: [wait, answered]
+          user:
             type: object
             properties:
               id:
                 type: integer
-              name:
+              nickname:
                 type: string
-      example:
-        id: 1
-        created_at: 2022-05-19T14:53:43.044Z
-        updated_at: 2022-05-19T14:53:43.044Z
-        title: 의뢰 게시물 제목
-        content: 게시물 내용
-        thumbnail: 의뢰 게시물 썸네일 url (or null)
-        likeCount: 3
-        bookmarkCount: 2
-        isLike: true
-        isBookmark: false
-        state: answered (or wait)
-        user:
+              profile_img:
+                type: string
+                nullable: true
+          categories:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type: integer
+                name:
+                  type: string
+        example:
           id: 1
-          nickname: test
-          profile_img: 프로필 사진 url (or null)
-        categories:
-          - id: 1
-            name: test
-          - id: 2
-            name: test2
+          created_at: 2022-05-19T14:53:43.044Z
+          updated_at: 2022-05-19T14:53:43.044Z
+          title: 의뢰 게시물 제목
+          content: 게시물 내용
+          thumbnail: 의뢰 게시물 썸네일 url (or null)
+          likeCount: 3
+          bookmarkCount: 2
+          isLike: true
+          isBookmark: false
+          state: answered (or wait)
+          user:
+            id: 1
+            nickname: test
+            profile_img: 프로필 사진 url (or null)
+          categories:
+            - id: 1
+              name: test
+            - id: 2
+              name: test2
 
-    ExperimentListByReq:
-      type: array
-      items:
+      ExperimentListByReq:
+        type: array
+        items:
+          type: object
+          properties:
+            id:
+              type: integer
+            created_at:
+              type: string
+            updated_at:
+              type: string
+            title:
+              type: string
+            thumbnail:
+              type: string
+              nullable: true
+            likeCount:
+              type: integer
+            user:
+              type: object
+              properties:
+                id:
+                  type: integer
+                nickname:
+                  type: string
+                profile_img:
+                  type: string
+                  nullable: true
+        example:
+          - id: 1
+            created_at: 2022-05-19T14:53:43.044Z
+            updated_at: 2022-05-19T14:53:43.044Z
+            title: 실험 게시물 제목
+            thumbnail: 실험 게시물 썸네일 url (or null)
+            likeCount: 3
+            user:
+              id: 1
+              nickname: test
+              profile_img: null(or img url)
+          - id: 2
+            created_at: 2022-05-19T14:53:43.044Z
+            updated_at: 2022-05-19T14:53:43.044Z
+            title: 실험 게시물 제목
+            thumbnail: 실험 게시물 썸네일
+            likeCount: 3
+            user:
+              id: 1
+              nickname: test
+              profile_img: 프로필 사진 url (or null)
+
+      RequestForExp:
         type: object
         properties:
           id:
@@ -150,6 +199,8 @@ components:
             nullable: true
           likeCount:
             type: integer
+          bookmarkCount:
+            type: integer
           user:
             type: object
             properties:
@@ -160,111 +211,97 @@ components:
               profile_img:
                 type: string
                 nullable: true
-      example:
-        - id: 1
+        example:
+          id: 1
           created_at: 2022-05-19T14:53:43.044Z
           updated_at: 2022-05-19T14:53:43.044Z
-          title: 실험 게시물 제목
-          thumbnail: 실험 게시물 썸네일 url (or null)
+          title: 의뢰 게시물 제목
+          thumbnail: 의뢰 게시물 썸네일 url (or null)
           likeCount: 3
-          user:
-            id: 1
-            nickname: test
-            profile_img: null(or img url)
-        - id: 2
-          created_at: 2022-05-19T14:53:43.044Z
-          updated_at: 2022-05-19T14:53:43.044Z
-          title: 실험 게시물 제목
-          thumbnail: 실험 게시물 썸네일
-          likeCount: 3
+          bookmarkCount: 1
           user:
             id: 1
             nickname: test
             profile_img: 프로필 사진 url (or null)
 
-    RequestForExp:
-      type: object
-      properties:
-        id:
-          type: integer
-        created_at:
-          type: string
-        updated_at:
-          type: string
-        title:
-          type: string
-        thumbnail:
-          type: string
-          nullable: true
-        likeCount:
-          type: integer
-        bookmarkCount:
-          type: integer
-        user:
+      Comments:
+        type: array
+        items:
           type: object
           properties:
             id:
               type: integer
-            nickname:
+            created_at:
               type: string
-            profile_img:
+            updated_at:
               type: string
+            content:
+              type: string
+            parent_id:
+              type: number
               nullable: true
-      example:
-        id: 1
-        created_at: 2022-05-19T14:53:43.044Z
-        updated_at: 2022-05-19T14:53:43.044Z
-        title: 의뢰 게시물 제목
-        thumbnail: 의뢰 게시물 썸네일 url (or null)
-        likeCount: 3
-        bookmarkCount: 1
-        user:
-          id: 1
-          nickname: test
-          profile_img: 프로필 사진 url (or null)
+            user:
+              type: object
+              properties:
+                id:
+                  type: integer
+                nickname:
+                  type: string
+                profile_img:
+                  type: string
+                  nullable: true
+        example:
+          - id: 1
+            created_at: 2022-05-19T14:53:43.044Z
+            updated_at: 2022-05-19T14:53:43.044Z
+            content: 댓글 내용
+            parent_id: null (대댓글인 경우 존재)
+            user:
+              id: 1
+              nickname: test
+              profile_img: null(or img url)
+          - id: 2
+            created_at: 2022-05-19T14:53:43.044Z
+            updated_at: 2022-05-19T14:53:43.044Z
+            content: 댓글 내용
+            parent_id: null (대댓글인 경우 존재)
+            user:
+              id: 1
+              nickname: test
+              profile_img: 프로필 사진 url (or null)
 
-    Comments:
-      type: array
-      items:
+    requestBodies:
+      Comments:
         type: object
         properties:
-          id:
-            type: integer
-          created_at:
+          content:
             type: string
-          updated_at:
+        example:
+          content: 댓글 내용
+      PostData:
+        type: object
+        properties:
+          title:
             type: string
           content:
             type: string
-          parent_id:
+          thumbnail:
+            type: string
+            nullable: true
+          categories:
+            type: array
+            items:
+              type: string
+              name:
+                type: string
+          reqId:
             type: number
             nullable: true
-          user:
-            type: object
-            properties:
-              id:
-                type: integer
-              nickname:
-                type: string
-              profile_img:
-                type: string
-                nullable: true
-      example:
-        - id: 1
-          created_at: 2022-05-19T14:53:43.044Z
-          updated_at: 2022-05-19T14:53:43.044Z
-          content: 댓글 내용
-          parent_id: null (대댓글인 경우 존재)
-          user:
-            id: 1
-            nickname: test
-            profile_img: null(or img url)
-        - id: 2
-          created_at: 2022-05-19T14:53:43.044Z
-          updated_at: 2022-05-19T14:53:43.044Z
-          content: 댓글 내용
-          parent_id: null (대댓글인 경우 존재)
-          user:
-            id: 1
-            nickname: test
-            profile_img: 프로필 사진 url (or null)
+        example:
+          title: 게시물 제목
+          content: 게시물 내용
+          thumbnail: 게시물 썸네일 url (or null)
+          categories:
+            - test1
+            - test2
+          reqId: 1 (실험 게시물인 경우, 의뢰에 대한 실험을 수행할 경우에만 or null)

--- a/src/swagger/components/post.yaml
+++ b/src/swagger/components/post.yaml
@@ -6,9 +6,9 @@ components:
         properties:
           id:
             type: integer
-          created_at:
+          createdAt:
             type: string
-          updated_at:
+          updatedAt:
             type: string
           title:
             type: string
@@ -32,7 +32,7 @@ components:
                 type: integer
               nickname:
                 type: string
-              profile_img:
+              profileImg:
                 type: string
                 nullable: true
           categories:
@@ -46,8 +46,8 @@ components:
                   type: string
         example:
           id: 1
-          created_at: 2022-05-19T14:53:43.044Z
-          updated_at: 2022-05-19T14:53:43.044Z
+          createdAt: 2022-05-19T14:53:43.044Z
+          updatedAt: 2022-05-19T14:53:43.044Z
           title: 실험 게시물 제목
           content: 게시물 내용
           thumbnail: 실험 게시물 썸네일 url (or null)
@@ -58,7 +58,7 @@ components:
           user:
             id: 1
             nickname: test
-            profile_img: 프로필 사진 url (or null)
+            profileImg: 프로필 사진 url (or null)
           categories:
             - id: 1
               name: test
@@ -70,9 +70,9 @@ components:
         properties:
           id:
             type: integer
-          created_at:
+          createdAt:
             type: string
-          updated_at:
+          updatedAt:
             type: string
           title:
             type: string
@@ -99,7 +99,7 @@ components:
                 type: integer
               nickname:
                 type: string
-              profile_img:
+              profileImg:
                 type: string
                 nullable: true
           categories:
@@ -113,8 +113,8 @@ components:
                   type: string
         example:
           id: 1
-          created_at: 2022-05-19T14:53:43.044Z
-          updated_at: 2022-05-19T14:53:43.044Z
+          createdAt: 2022-05-19T14:53:43.044Z
+          updatedAt: 2022-05-19T14:53:43.044Z
           title: 의뢰 게시물 제목
           content: 게시물 내용
           thumbnail: 의뢰 게시물 썸네일 url (or null)
@@ -126,7 +126,7 @@ components:
           user:
             id: 1
             nickname: test
-            profile_img: 프로필 사진 url (or null)
+            profileImg: 프로필 사진 url (or null)
           categories:
             - id: 1
               name: test
@@ -140,9 +140,9 @@ components:
           properties:
             id:
               type: integer
-            created_at:
+            createdAt:
               type: string
-            updated_at:
+            updatedAt:
               type: string
             title:
               type: string
@@ -158,39 +158,39 @@ components:
                   type: integer
                 nickname:
                   type: string
-                profile_img:
+                profileImg:
                   type: string
                   nullable: true
         example:
           - id: 1
-            created_at: 2022-05-19T14:53:43.044Z
-            updated_at: 2022-05-19T14:53:43.044Z
+            createdAt: 2022-05-19T14:53:43.044Z
+            updatedAt: 2022-05-19T14:53:43.044Z
             title: 실험 게시물 제목
             thumbnail: 실험 게시물 썸네일 url (or null)
             likeCount: 3
             user:
               id: 1
               nickname: test
-              profile_img: null(or img url)
+              profileImg: null(or img url)
           - id: 2
-            created_at: 2022-05-19T14:53:43.044Z
-            updated_at: 2022-05-19T14:53:43.044Z
+            createdAt: 2022-05-19T14:53:43.044Z
+            updatedAt: 2022-05-19T14:53:43.044Z
             title: 실험 게시물 제목
             thumbnail: 실험 게시물 썸네일
             likeCount: 3
             user:
               id: 1
               nickname: test
-              profile_img: 프로필 사진 url (or null)
+              profileImg: 프로필 사진 url (or null)
 
       RequestForExp:
         type: object
         properties:
           id:
             type: integer
-          created_at:
+          createdAt:
             type: string
-          updated_at:
+          updatedAt:
             type: string
           title:
             type: string
@@ -208,13 +208,13 @@ components:
                 type: integer
               nickname:
                 type: string
-              profile_img:
+              profileImg:
                 type: string
                 nullable: true
         example:
           id: 1
-          created_at: 2022-05-19T14:53:43.044Z
-          updated_at: 2022-05-19T14:53:43.044Z
+          createdAt: 2022-05-19T14:53:43.044Z
+          updatedAt: 2022-05-19T14:53:43.044Z
           title: 의뢰 게시물 제목
           thumbnail: 의뢰 게시물 썸네일 url (or null)
           likeCount: 3
@@ -222,7 +222,7 @@ components:
           user:
             id: 1
             nickname: test
-            profile_img: 프로필 사진 url (or null)
+            profileImg: 프로필 사진 url (or null)
 
       Comments:
         type: array
@@ -231,13 +231,13 @@ components:
           properties:
             id:
               type: integer
-            created_at:
+            createdAt:
               type: string
-            updated_at:
+            updatedAt:
               type: string
             content:
               type: string
-            parent_id:
+            parentId:
               type: number
               nullable: true
             user:
@@ -247,28 +247,28 @@ components:
                   type: integer
                 nickname:
                   type: string
-                profile_img:
+                profileImg:
                   type: string
                   nullable: true
         example:
           - id: 1
-            created_at: 2022-05-19T14:53:43.044Z
-            updated_at: 2022-05-19T14:53:43.044Z
+            createdAt: 2022-05-19T14:53:43.044Z
+            updatedAt: 2022-05-19T14:53:43.044Z
             content: 댓글 내용
-            parent_id: null (대댓글인 경우 존재)
+            parentId: null (대댓글인 경우 존재)
             user:
               id: 1
               nickname: test
-              profile_img: null(or img url)
+              profileImg: null(or img url)
           - id: 2
-            created_at: 2022-05-19T14:53:43.044Z
-            updated_at: 2022-05-19T14:53:43.044Z
+            createdAt: 2022-05-19T14:53:43.044Z
+            updatedAt: 2022-05-19T14:53:43.044Z
             content: 댓글 내용
-            parent_id: null (대댓글인 경우 존재)
+            parentId: null (대댓글인 경우 존재)
             user:
               id: 1
               nickname: test
-              profile_img: 프로필 사진 url (or null)
+              profileImg: 프로필 사진 url (or null)
 
     requestBodies:
       Comments:

--- a/src/swagger/components/posts.yaml
+++ b/src/swagger/components/posts.yaml
@@ -8,9 +8,9 @@ components:
           properties:
             id:
               type: integer
-            created_at:
+            createdAt:
               type: string
-            updated_at:
+            updatedAt:
               type: string
             title:
               type: string
@@ -26,7 +26,7 @@ components:
                   type: integer
                 nickname:
                   type: string
-                profile_img:
+                profileImg:
                   type: string
                   nullable: true
             categories:
@@ -40,30 +40,30 @@ components:
                     type: string
         example:
           - id: 1
-            created_at: 2022-05-19T14:53:43.044Z
-            updated_at: 2022-05-19T14:53:43.044Z
+            createdAt: 2022-05-19T14:53:43.044Z
+            updatedAt: 2022-05-19T14:53:43.044Z
             title: 실험 게시물 제목
             thumbnail: 실험 게시물 썸네일 url (or null)
             likeCount: 3
             user:
               id: 1
               nickname: test
-              profile_img: 프로필 사진 url (or null)
+              profileImg: 프로필 사진 url (or null)
             categories:
               - id: 1
                 name: test
               - id: 2
                 name: test2
           - id: 2
-            created_at: 2022-05-19T14:53:43.044Z
-            updated_at: 2022-05-19T14:53:43.044Z
+            createdAt: 2022-05-19T14:53:43.044Z
+            updatedAt: 2022-05-19T14:53:43.044Z
             title: 실험 게시물 제목
             thumbnail: 실험 게시물 썸네일 url (or null)
             likeCount: 3
             user:
               id: 1
               nickname: test
-              profile_img: 프로필 사진 url (or null)
+              profileImg: 프로필 사진 url (or null)
             categories:
               - id: 1
                 name: test
@@ -77,9 +77,9 @@ components:
           properties:
             id:
               type: integer
-            created_at:
+            createdAt:
               type: string
-            updated_at:
+            updatedAt:
               type: string
             title:
               type: string
@@ -98,7 +98,7 @@ components:
                   type: integer
                 nickname:
                   type: string
-                profile_img:
+                profileImg:
                   type: string
                   nullable: true
             categories:
@@ -112,8 +112,8 @@ components:
                     type: string
         example:
           - id: 1
-            created_at: 2022-05-19T14:53:43.044Z
-            updated_at: 2022-05-19T14:53:43.044Z
+            createdAt: 2022-05-19T14:53:43.044Z
+            updatedAt: 2022-05-19T14:53:43.044Z
             title: 의뢰 게시물 제목
             thumbnail: 의뢰 게시물 썸네일 url (or null)
             likeCount: 3
@@ -121,15 +121,15 @@ components:
             user:
               id: 1
               nickname: test
-              profile_img: 프로필 사진 url (or null)
+              profileImg: 프로필 사진 url (or null)
             categories:
               - id: 1
                 name: test
               - id: 2
                 name: test2
           - id: 2
-            created_at: 2022-05-19T14:53:43.044Z
-            updated_at: 2022-05-19T14:53:43.044Z
+            createdAt: 2022-05-19T14:53:43.044Z
+            updatedAt: 2022-05-19T14:53:43.044Z
             title: 의뢰 게시물 제목
             thumbnail: 의뢰 게시물 썸네일 url (or null)
             likeCount: 3
@@ -137,7 +137,7 @@ components:
             user:
               id: 1
               nickname: test
-              profile_img: 프로필 사진 url (or null)
+              profileImg: 프로필 사진 url (or null)
             categories:
               - id: 1
                 name: test

--- a/src/swagger/components/posts.yaml
+++ b/src/swagger/components/posts.yaml
@@ -1,144 +1,145 @@
 components:
   schemas:
-    ExperimentList:
-      type: array
-      items:
-        type: object
-        properties:
-          id:
-            type: integer
-          created_at:
-            type: string
-          updated_at:
-            type: string
-          title:
-            type: string
-          thumbnail:
-            type: string
-            nullable: true
-          likeCount:
-            type: integer
-          user:
-            type: object
-            properties:
-              id:
-                type: integer
-              nickname:
-                type: string
-              profile_img:
-                type: string
-                nullable: true
-          categories:
-            type: array
-            items:
+    responseBodies:
+      ExperimentList:
+        type: array
+        items:
+          type: object
+          properties:
+            id:
+              type: integer
+            created_at:
+              type: string
+            updated_at:
+              type: string
+            title:
+              type: string
+            thumbnail:
+              type: string
+              nullable: true
+            likeCount:
+              type: integer
+            user:
               type: object
               properties:
                 id:
                   type: integer
-                name:
+                nickname:
                   type: string
-      example:
-        - id: 1
-          created_at: 2022-05-19T14:53:43.044Z
-          updated_at: 2022-05-19T14:53:43.044Z
-          title: 실험 게시물 제목
-          thumbnail: 실험 게시물 썸네일 url (or null)
-          likeCount: 3
-          user:
-            id: 1
-            nickname: test
-            profile_img: 프로필 사진 url (or null)
-          categories:
-            - id: 1
-              name: test
-            - id: 2
-              name: test2
-        - id: 2
-          created_at: 2022-05-19T14:53:43.044Z
-          updated_at: 2022-05-19T14:53:43.044Z
-          title: 실험 게시물 제목
-          thumbnail: 실험 게시물 썸네일 url (or null)
-          likeCount: 3
-          user:
-            id: 1
-            nickname: test
-            profile_img: 프로필 사진 url (or null)
-          categories:
-            - id: 1
-              name: test
-            - id: 2
-              name: test2
+                profile_img:
+                  type: string
+                  nullable: true
+            categories:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+        example:
+          - id: 1
+            created_at: 2022-05-19T14:53:43.044Z
+            updated_at: 2022-05-19T14:53:43.044Z
+            title: 실험 게시물 제목
+            thumbnail: 실험 게시물 썸네일 url (or null)
+            likeCount: 3
+            user:
+              id: 1
+              nickname: test
+              profile_img: 프로필 사진 url (or null)
+            categories:
+              - id: 1
+                name: test
+              - id: 2
+                name: test2
+          - id: 2
+            created_at: 2022-05-19T14:53:43.044Z
+            updated_at: 2022-05-19T14:53:43.044Z
+            title: 실험 게시물 제목
+            thumbnail: 실험 게시물 썸네일 url (or null)
+            likeCount: 3
+            user:
+              id: 1
+              nickname: test
+              profile_img: 프로필 사진 url (or null)
+            categories:
+              - id: 1
+                name: test
+              - id: 2
+                name: test2
 
-    RequestList:
-      type: array
-      items:
-        type: object
-        properties:
-          id:
-            type: integer
-          created_at:
-            type: string
-          updated_at:
-            type: string
-          title:
-            type: string
-          thumbnail:
-            type: string
-            nullable: true
-          likeCount:
-            type: integer
-          state:
-            type: string
-            enum: [wait, answered]
-          user:
-            type: object
-            properties:
-              id:
-                type: integer
-              nickname:
-                type: string
-              profile_img:
-                type: string
-                nullable: true
-          categories:
-            type: array
-            items:
+      RequestList:
+        type: array
+        items:
+          type: object
+          properties:
+            id:
+              type: integer
+            created_at:
+              type: string
+            updated_at:
+              type: string
+            title:
+              type: string
+            thumbnail:
+              type: string
+              nullable: true
+            likeCount:
+              type: integer
+            state:
+              type: string
+              enum: [wait, answered]
+            user:
               type: object
               properties:
                 id:
                   type: integer
-                name:
+                nickname:
                   type: string
-      example:
-        - id: 1
-          created_at: 2022-05-19T14:53:43.044Z
-          updated_at: 2022-05-19T14:53:43.044Z
-          title: 의뢰 게시물 제목
-          thumbnail: 의뢰 게시물 썸네일 url (or null)
-          likeCount: 3
-          state: wait (or answered)
-          user:
-            id: 1
-            nickname: test
-            profile_img: 프로필 사진 url (or null)
-          categories:
-            - id: 1
-              name: test
-            - id: 2
-              name: test2
-        - id: 2
-          created_at: 2022-05-19T14:53:43.044Z
-          updated_at: 2022-05-19T14:53:43.044Z
-          title: 의뢰 게시물 제목
-          thumbnail: 의뢰 게시물 썸네일 url (or null)
-          likeCount: 3
-          state: wait (or answered)
-          user:
-            id: 1
-            nickname: test
-            profile_img: 프로필 사진 url (or null)
-          categories:
-            - id: 1
-              name: test
-            - id: 2
-              name: test2
+                profile_img:
+                  type: string
+                  nullable: true
+            categories:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+        example:
+          - id: 1
+            created_at: 2022-05-19T14:53:43.044Z
+            updated_at: 2022-05-19T14:53:43.044Z
+            title: 의뢰 게시물 제목
+            thumbnail: 의뢰 게시물 썸네일 url (or null)
+            likeCount: 3
+            state: wait (or answered)
+            user:
+              id: 1
+              nickname: test
+              profile_img: 프로필 사진 url (or null)
+            categories:
+              - id: 1
+                name: test
+              - id: 2
+                name: test2
+          - id: 2
+            created_at: 2022-05-19T14:53:43.044Z
+            updated_at: 2022-05-19T14:53:43.044Z
+            title: 의뢰 게시물 제목
+            thumbnail: 의뢰 게시물 썸네일 url (or null)
+            likeCount: 3
+            state: wait (or answered)
+            user:
+              id: 1
+              nickname: test
+              profile_img: 프로필 사진 url (or null)
+            categories:
+              - id: 1
+                name: test
+              - id: 2
+                name: test2

--- a/src/swagger/components/user.yaml
+++ b/src/swagger/components/user.yaml
@@ -1,29 +1,30 @@
 components:
   schemas:
-    User:
-      type: 'object'
-      properties:
-        id:
-          type: 'integer'
-        created_at:
-          type: 'string'
-        updated_at:
-          type: 'string'
-        email:
-          type: 'string'
-        login_type:
-          type: 'string'
-          enum: ['google', 'kakao', 'apple']
-        nickname:
-          type: 'string'
-        profile_img:
-          type: 'string'
-          nullable: true
-      example:
-        id: 1
-        created_at: 2022-03-27T15:56:04.904Z
-        updated_at: 2022-03-27T15:56:04.904Z
-        email: test@google.com
-        login_type: google
-        nickname: test
-        profile_img: null
+    responseBodies:
+      User:
+        type: 'object'
+        properties:
+          id:
+            type: 'integer'
+          created_at:
+            type: 'string'
+          updated_at:
+            type: 'string'
+          email:
+            type: 'string'
+          login_type:
+            type: 'string'
+            enum: ['google', 'kakao', 'apple']
+          nickname:
+            type: 'string'
+          profile_img:
+            type: 'string'
+            nullable: true
+        example:
+          id: 1
+          created_at: 2022-03-27T15:56:04.904Z
+          updated_at: 2022-03-27T15:56:04.904Z
+          email: test@google.com
+          login_type: google
+          nickname: test
+          profile_img: null

--- a/src/swagger/components/user.yaml
+++ b/src/swagger/components/user.yaml
@@ -6,25 +6,25 @@ components:
         properties:
           id:
             type: 'integer'
-          created_at:
+          createdAt:
             type: 'string'
-          updated_at:
+          updatedAt:
             type: 'string'
           email:
             type: 'string'
-          login_type:
+          loginType:
             type: 'string'
             enum: ['google', 'kakao', 'apple']
           nickname:
             type: 'string'
-          profile_img:
+          profileImg:
             type: 'string'
             nullable: true
         example:
           id: 1
-          created_at: 2022-03-27T15:56:04.904Z
-          updated_at: 2022-03-27T15:56:04.904Z
+          createdAt: 2022-03-27T15:56:04.904Z
+          updatedAt: 2022-03-27T15:56:04.904Z
           email: test@google.com
-          login_type: google
+          loginType: google
           nickname: test
-          profile_img: null
+          profileImg: null

--- a/src/swagger/routes/auth.yaml
+++ b/src/swagger/routes/auth.yaml
@@ -34,28 +34,28 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '401':
           description: 인증 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '403':
           description: 요청 거부 오류 (권한 없음)
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '404':
           description: 존재하지 않는 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'

--- a/src/swagger/routes/post.yaml
+++ b/src/swagger/routes/post.yaml
@@ -23,25 +23,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ExperimentDetail'
+                $ref: '#/components/schemas/responseBodies/ExperimentDetail'
         '400':
           description: 잘못된 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '404':
           description: 존재하지 않는 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
 
   /post/request/{postId}:
     get:
@@ -63,25 +63,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RequestDetail'
+                $ref: '#/components/schemas/responseBodies/RequestDetail'
         '400':
           description: 잘못된 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '404':
           description: 존재하지 않는 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
 
   /post/request/{reqId}/experiments:
     get:
@@ -101,25 +101,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ExperimentListByReq'
+                $ref: '#/components/schemas/responseBodies/ExperimentListByReq'
         '400':
           description: 잘못된 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '404':
           description: 존재하지 않는 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
 
   /post/experiment/{expId}/request:
     get:
@@ -139,25 +139,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RequestForExp'
+                $ref: '#/components/schemas/responseBodies/RequestForExp'
         '400':
           description: 잘못된 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '404':
           description: 존재하지 않는 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
 
   /post/{postType}/{postId}/comments:
     get:
@@ -194,25 +194,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Comments'
+                $ref: '#/components/schemas/responseBodies/Comments'
         '400':
           description: 잘못된 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '404':
           description: 존재하지 않는 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
 
   /post/{postType}/{postId}/comment:
     post:
@@ -233,6 +233,11 @@ paths:
           description: 게시물 id값
           schema:
             type: number
+        - in: body
+          name: comment
+          description: 댓글 내용
+          schema:
+            $ref: '#/components/schemas/requestBodies/Comments'
       security:
         - sasil-access-token: []
       responses:
@@ -243,25 +248,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '401':
           description: 인증 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '404':
           description: 존재하지 않는 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
 
   /post/{postType}/{postId}/comment/{commentId}:
     delete:
@@ -298,25 +303,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '401':
           description: 인증 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '404':
           description: 존재하지 않는 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
 
   /post/{postType}/{postId}/like:
     post:
@@ -347,25 +352,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '401':
           description: 인증 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '404':
           description: 존재하지 않는 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
 
     delete:
       summary: 좋아요 삭제
@@ -395,25 +400,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '401':
           description: 인증 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '404':
           description: 존재하지 않는 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
 
   /post/{postType}/{postId}/bookmark:
     post:
@@ -444,25 +449,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '401':
           description: 인증 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '404':
           description: 존재하지 않는 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
 
     delete:
       summary: 북마크 삭제
@@ -492,22 +497,70 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '401':
           description: 인증 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '404':
           description: 존재하지 않는 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
+
+  /post/{postType}:
+    post:
+      summary: 게시물 추가
+      tags:
+        - Post
+      parameters:
+        - in: path
+          name: postType
+          required: true
+          description: 게시물 종류
+          schema:
+            type: string
+            enum: ['experiment', 'request']
+        - in: body
+          name: postData
+          description: 게시물 데이터
+          schema:
+            $ref: '#/components/schemas/requestBodies/PostData'
+      security:
+        - sasil-access-token: []
+      responses:
+        '200':
+          description: 요청 성공 (body X)
+        '400':
+          description: 잘못된 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responseBodies/Error'
+        '401':
+          description: 인증 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responseBodies/Error'
+        '404':
+          description: 존재하지 않는 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responseBodies/Error'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responseBodies/Error'

--- a/src/swagger/routes/post.yaml
+++ b/src/swagger/routes/post.yaml
@@ -564,3 +564,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/responseBodies/Error'
+
+  /post/image:
+    get:
+      summary: 이미지 업로드 URL
+      tags:
+        - Post
+      security:
+        - sasil-access-token: []
+      responses:
+        '200':
+          description: 수신 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  imgUploadURL:
+                    type: string

--- a/src/swagger/routes/post.yaml
+++ b/src/swagger/routes/post.yaml
@@ -519,7 +519,7 @@ paths:
 
   /post/{postType}:
     post:
-      summary: 게시물 추가
+      summary: 게시물 작성
       tags:
         - Post
       parameters:

--- a/src/swagger/routes/posts.yaml
+++ b/src/swagger/routes/posts.yaml
@@ -31,25 +31,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ExperimentList'
+                $ref: '#/components/schemas/responseBodies/ExperimentList'
         '400':
           description: 잘못된 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '404':
           description: 존재하지 않는 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
 
   /posts/request:
     get:
@@ -85,22 +85,22 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RequestList'
+                $ref: '#/components/schemas/responseBodies/RequestList'
         '400':
           description: 잘못된 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '404':
           description: 존재하지 않는 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'

--- a/src/swagger/routes/user.yaml
+++ b/src/swagger/routes/user.yaml
@@ -16,28 +16,28 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/responseBodies/User'
         '400':
           description: 잘못된 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '401':
           description: 인증 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '404':
           description: 존재하지 않는 요청 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/responseBodies/Error'

--- a/src/utils/uploadImage.ts
+++ b/src/utils/uploadImage.ts
@@ -29,7 +29,7 @@ export const getImgUploadURL = async () => {
       },
     );
 
-    return imageResponse.data.result.uploadURL;
+    return { imgUploadURL: imageResponse.data.result.uploadURL };
   } catch (error) {
     throw new ServerError('이미지 업로드 URL을 받아오는데 실패하였습니다.');
   }

--- a/src/utils/uploadImage.ts
+++ b/src/utils/uploadImage.ts
@@ -1,0 +1,39 @@
+/* eslint-disable import/prefer-default-export */
+import axios from 'axios';
+import dotenv from 'dotenv';
+import { ServerError } from '@/errors/customErrors';
+
+dotenv.config();
+
+interface ResponseType {
+  success: boolean;
+  errors: any[];
+  messages: any[];
+  result: {
+    id: string;
+    uploadURL: string;
+  };
+  result_info: string | null;
+}
+
+// Direct Creator Upload 방식
+export const getImgUploadURL = async () => {
+  const imageResponse = await axios.post<ResponseType>(
+    `https://api.cloudflare.com/client/v4/accounts/${process.env.CF_ACCOUNT_ID}/images/v2/direct_upload`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.CF_API_TOKEN}`,
+      },
+    },
+  );
+
+  if (!imageResponse.data.success) {
+    throw new ServerError('이미지 업로드 URL을 받아오는데 실패하였습니다.');
+  }
+
+  const { uploadURL } = imageResponse.data.result;
+
+  return uploadURL;
+};

--- a/src/utils/uploadImage.ts
+++ b/src/utils/uploadImage.ts
@@ -18,22 +18,19 @@ interface ResponseType {
 
 // Direct Creator Upload 방식
 export const getImgUploadURL = async () => {
-  const imageResponse = await axios.post<ResponseType>(
-    `https://api.cloudflare.com/client/v4/accounts/${process.env.CF_ACCOUNT_ID}/images/v2/direct_upload`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.CF_API_TOKEN}`,
+  try {
+    const imageResponse = await axios.post<ResponseType>(
+      `https://api.cloudflare.com/client/v4/accounts/${process.env.CF_ACCOUNT_ID}/images/v2/direct_upload`,
+      null,
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.CF_API_TOKEN}`,
+        },
       },
-    },
-  );
+    );
 
-  if (!imageResponse.data.success) {
+    return imageResponse.data.result.uploadURL;
+  } catch (error) {
     throw new ServerError('이미지 업로드 URL을 받아오는데 실패하였습니다.');
   }
-
-  const { uploadURL } = imageResponse.data.result;
-
-  return uploadURL;
 };


### PR DESCRIPTION
## Issue
#33 

## Description
### 리팩토링
실험/의뢰 게시물 작성 페이지에서 사용되는 카테고리 관련 로직의 효율성을 높이기 위한 DB 리팩토링
(이로써 모든 M:N 관계의 테이블들을 ManyToMany -> OneToMany + ManyToOne 방식으로 변경완료..!)

### PostWrite 페이지에서 사용되는 api 구현
- 게시글 작성
- 이미지 업로드 URL 조회(수신)

### 변수명 표기법
기존 백엔드에서 api로 제공하는 변수들의 표기법에 혼용이 있었는데, `Camel Case`로 모두 통일!
-> 프론트에서 사용하는 대부분의 변수들의 표기법이 Camel Case를 따르고 있고, 백엔드에서 받아온 데이터들을 그대로 가져와서 저장하기 때문에, 백엔드에서 Snake Case 표기법을 사용하면 프론트에서도 네이밍 문법에 혼용이 생길 것이라고 생각했슴다..
만약, 이부분에 대해서 얘기할게 있다면 언제든 편하게 주십셔!!

## Check List
- [x] PR 제목을 commit 규칙에 맞게 작성
- [x] WIP를 붙여야 하는 상황인지 확인
- [x] label 설정
- [x] 작업한 사람 모두를 Assign
- [x] Code Review 요청
