### PR TITLE
feat: add user delete api with soft-delete

### DIFF
--- a/src/database/controllers/user.ts
+++ b/src/database/controllers/user.ts
@@ -1,7 +1,7 @@
 import { getRepository } from 'typeorm';
 
-import { ServerError } from '@/errors/customErrors';
 import UserEntity, { LoginTypes } from '@/database/entity/user';
+import { BadRequestError, ServerError } from '@/errors/customErrors';
 
 /**
  * id값으로 DB에서 유저 데이터 가져와 반환하는 함수
@@ -72,4 +72,22 @@ export const addUser = async (
   await userRepository.save(newUserData);
 
   return newUserData;
+};
+
+/**
+ * 회원탈퇴 기능을 하는 함수
+ *
+ * @param userId 유저의 id값
+ * @returns
+ */
+export const deleteUser = async (userId: number) => {
+  const deleteResult = await getRepository(UserEntity)
+    .createQueryBuilder('user')
+    .softDelete()
+    .where(`user.id = :userId`, { userId })
+    .execute();
+
+  if (deleteResult.affected !== 1) {
+    throw new BadRequestError('존재하지 않는 유저에 대한 삭제 요청입니다.');
+  }
 };

--- a/src/database/entity/user.ts
+++ b/src/database/entity/user.ts
@@ -16,10 +16,14 @@ export type LoginTypes = 'apple' | 'google' | 'kakao';
 
 @Entity()
 class User extends BasicEntity {
-  @Column('varchar', { length: 255 })
+  @Column('varchar', { length: 255, select: false })
   email!: string;
 
-  @Column('enum', { name: 'login_type', enum: ['kakao', 'google', 'apple'] })
+  @Column('enum', {
+    name: 'login_type',
+    enum: ['kakao', 'google', 'apple'],
+    select: false,
+  })
   loginType!: LoginTypes;
 
   @Column('varchar', { length: 30 })
@@ -69,7 +73,7 @@ class User extends BasicEntity {
   reqBookmarks!: ReqBookmark[];
 
   //
-  @DeleteDateColumn({ name: 'deleted_at' })
+  @DeleteDateColumn({ name: 'deleted_at', select: false })
   deletedDate!: Date;
 }
 

--- a/src/database/entity/user.ts
+++ b/src/database/entity/user.ts
@@ -72,7 +72,7 @@ class User extends BasicEntity {
   @OneToMany(() => ReqBookmark, (reqBookmark) => reqBookmark.user)
   reqBookmarks!: ReqBookmark[];
 
-  //
+  // 삭제된 날짜 (기본: Null)
   @DeleteDateColumn({ name: 'deleted_at', select: false })
   deletedDate!: Date;
 }

--- a/src/database/entity/user.ts
+++ b/src/database/entity/user.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-cycle */
-import { Entity, Column, OneToMany } from 'typeorm';
+import { Entity, Column, OneToMany, DeleteDateColumn } from 'typeorm';
 
 import BasicEntity from './basic-entity';
 import Experiment from './experiment';
@@ -67,6 +67,10 @@ class User extends BasicEntity {
   // User:ReqBookmark = 1:N
   @OneToMany(() => ReqBookmark, (reqBookmark) => reqBookmark.user)
   reqBookmarks!: ReqBookmark[];
+
+  //
+  @DeleteDateColumn({ name: 'deleted_at' })
+  deletedDate!: Date;
 }
 
 export default User;

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -11,7 +11,13 @@ router.get(
   '/me',
   checkLoggedIn,
   wrapAsync(async (req: Request, res: Response) => {
-    const userData = await getUserById(req.userId!);
+    const { userId } = req;
+
+    if (!userId) {
+      throw new UnauthorizedError('로그인이 필요한 요청입니다.');
+    }
+
+    const userData = await getUserById(userId);
     return res.json(userData);
   }),
 );

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -1,8 +1,9 @@
 import express, { Request, Response } from 'express';
 
 import wrapAsync from '@/utils/wrapAsync';
-import { getUserById } from '@/database/controllers/user';
+import { deleteUser, getUserById } from '@/database/controllers/user';
 import { checkLoggedIn } from './middleware';
+import { UnauthorizedError } from '@/errors/customErrors';
 
 const router = express.Router();
 
@@ -12,6 +13,22 @@ router.get(
   wrapAsync(async (req: Request, res: Response) => {
     const userData = await getUserById(req.userId!);
     return res.json(userData);
+  }),
+);
+
+router.delete(
+  '/me',
+  checkLoggedIn,
+  wrapAsync(async (req: Request, res: Response) => {
+    const { userId } = req;
+
+    if (!userId) {
+      throw new UnauthorizedError('로그인이 필요한 요청입니다.');
+    }
+
+    await deleteUser(userId);
+
+    res.end();
   }),
 );
 

--- a/src/swagger/components/post.yaml
+++ b/src/swagger/components/post.yaml
@@ -26,6 +26,7 @@ components:
           type: boolean
         user:
           type: object
+          nullable: true
           properties:
             id:
               type: integer
@@ -93,6 +94,7 @@ components:
           enum: [wait, answered]
         user:
           type: object
+          nullable: true
           properties:
             id:
               type: integer
@@ -152,6 +154,7 @@ components:
             type: integer
           user:
             type: object
+            nullable: true
             properties:
               id:
                 type: integer
@@ -200,6 +203,7 @@ components:
             nullable: true
           user:
             type: object
+            nullable: true
             properties:
               id:
                 type: integer

--- a/src/swagger/components/posts.yaml
+++ b/src/swagger/components/posts.yaml
@@ -20,6 +20,7 @@ components:
             type: integer
           user:
             type: object
+            nullable: true
             properties:
               id:
                 type: integer
@@ -92,6 +93,7 @@ components:
             enum: [wait, answered]
           user:
             type: object
+            nullable: true
             properties:
               id:
                 type: integer

--- a/src/swagger/components/user.yaml
+++ b/src/swagger/components/user.yaml
@@ -9,11 +9,6 @@ components:
           type: 'string'
         updatedAt:
           type: 'string'
-        email:
-          type: 'string'
-        loginType:
-          type: 'string'
-          enum: ['google', 'kakao', 'apple']
         nickname:
           type: 'string'
         profileImg:
@@ -23,7 +18,5 @@ components:
         id: 1
         createdAt: 2022-03-27T15:56:04.904Z
         updatedAt: 2022-03-27T15:56:04.904Z
-        email: test@google.com
-        loginType: google
         nickname: test
         profileImg: null

--- a/src/swagger/routes/user.yaml
+++ b/src/swagger/routes/user.yaml
@@ -41,3 +41,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+
+    delete:
+      summary: 회원 탈퇴 (인증 필요)
+      tags:
+        - User
+      security:
+        - sasil-access-token: []
+      responses:
+        '200':
+          description: 요청 성공 (body X)
+        '400':
+          description: 잘못된 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: 인증 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: 존재하지 않는 요청 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'


### PR DESCRIPTION
## Issue
#40 

## Description
- 회원 탈퇴를 `soft-delete` 방식으로 추가
- 같은 계정으로 재가입 시, 새롭게 가입되도록 구현
- 기존 조회 관련 데이터에서, 유저 정보는 `null`로 반환되도록 처리
- 유저 정보 조회에서 불필요한 데이터 (`email`, `login_type`, `deleted_at`)는 조회되지 않도록 리팩토링

## Check List
- [x] PR 제목을 commit 규칙에 맞게 작성
- [x] WIP를 붙여야 하는 상황인지 확인
- [x] label 설정
- [x] 작업한 사람 모두를 Assign
- [x] Code Review 요청
